### PR TITLE
Add caveman mode skill for token-efficient communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ Settings live in two places:
 | `command_gate_timeout` | milliseconds | `3000` | Codex safety classification timeout |
 | `speculative_review` | `on` `off` | `on` | Background review of previous tier |
 | `speculative_review_timeout` | seconds | `300` | Max wait for speculative results |
+| `caveman_mode` | `on` `off` | `on` | Token-compressed output (~75% savings) |
+| `caveman_phases` | comma-separated | `build,inspect` | Which phases use caveman-speak |
 
 **Model presets:**
 
@@ -526,7 +528,7 @@ Cavekit applies the **scientific method** to AI-generated code. LLMs are non-det
 Ships with 9 specialized agents (including **design-reviewer** for UI validation against DESIGN.md), a multi-agent research system, and 15 skills covering the full methodology. With Codex, operates as a **dual-model architecture** — Claude builds, Codex reviews — catching errors single-model self-review cannot.
 
 <details>
-<summary><strong>All 15 skills</strong></summary>
+<summary><strong>All 16 skills</strong></summary>
 
 | Skill | What it covers |
 |-------|---------------|
@@ -545,6 +547,7 @@ Ships with 9 specialized agents (including **design-reviewer** for UI validation
 | [Documentation Inversion](skills/documentation-inversion) | Docs for agents, not just humans |
 | [Peer Review Loop](skills/peer-review-loop) | Combine build loop with cross-model review |
 | [Core Methodology](skills/methodology) | The full DABI lifecycle |
+| [Caveman](skills/caveman) | Token-compressed output (~75% savings), built-in for build/inspect phases |
 
 </details>
 
@@ -572,7 +575,7 @@ If cavekit save you mass debug time — leave star.
 
 ## Also by Julius Brussee
 
-- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. `npx skills add JuliusBrussee/caveman`
+- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. Now bundled in Cavekit (skill #16) and enabled by default for build/inspect phases. Standalone install: `npx skills add JuliusBrussee/caveman`
 - **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ If cavekit save you mass debug time — leave star.
 
 ## Also by Julius Brussee
 
-- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. Now bundled in Cavekit (skill #16) and enabled by default for build/inspect phases. Standalone install: `npx skills add JuliusBrussee/caveman`
+- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. Bundled in Cavekit and enabled by default for build/inspect phases. Standalone install: `npx skills add JuliusBrussee/caveman`
 - **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
 
 ## License

--- a/agents/task-builder.md
+++ b/agents/task-builder.md
@@ -7,6 +7,8 @@ tools: [All tools]
 
 You are a task builder for Cavekit. You implement exactly ONE task, validate it, commit it, and stop.
 
+**Caveman Mode:** If your dispatch prompt includes `CAVEMAN MODE: ON`, use caveman-speak for all status reports, logs, and reasoning (drop articles, filler, pleasantries — keep technical terms exact). Code blocks, git commits, and structured output fields (TASK RESULT) stay in normal format.
+
 ## Input
 
 You receive:

--- a/commands/architect.md
+++ b/commands/architect.md
@@ -16,6 +16,7 @@ Before generating the site:
 
 1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" summary` and print that exact line once.
 2. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" model reasoning` and treat the result as `REASONING_MODEL`.
+3. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" caveman-active architect` and treat the result as `CAVEMAN_ACTIVE` (true/false). Architect phase is NOT in the default caveman_phases, so this will typically be false. If true, apply caveman-speak to status updates and architect subagent reasoning only — never to build site content (task titles, descriptions, coverage matrix).
 
 Do NOT rely on the agent frontmatter model. Dispatch the actual site-generation work to a `bp:architect` subagent with `model: "{REASONING_MODEL}"`.
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -19,7 +19,9 @@ Before starting waves:
 
 1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" summary` and report that exact line once.
 2. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" model execution` and treat the result as `EXECUTION_MODEL`.
-3. Use that exact `EXECUTION_MODEL` string in every `bp:task-builder` delegation below. Do not hard-code `opus`, `sonnet`, or `haiku` in this command.
+3. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" caveman-active build` and treat the result as `CAVEMAN_ACTIVE` (true/false).
+4. Use that exact `EXECUTION_MODEL` string in every `bp:task-builder` delegation below. Do not hard-code `opus`, `sonnet`, or `haiku` in this command.
+5. If `CAVEMAN_ACTIVE` is `true`, all your own wave logs, iteration summaries, and status reports in this command should use caveman-speak (drop articles, filler, pleasantries — keep technical terms exact, code blocks unchanged). Spec artifacts (kits, build sites, impl tracking field values) stay in normal prose.
 
 ## Pre-flight Coverage Check
 
@@ -98,6 +100,8 @@ Once the setup script completes (outputs the ralph prompt), you run the executio
    DEAD ENDS TO AVOID:
    {paste relevant dead ends, or 'None'}
 
+   CAVEMAN MODE: {if CAVEMAN_ACTIVE is true, include: 'ON — all status reports, logs, and reasoning use caveman-speak: drop articles/filler/pleasantries, keep technical terms exact, code blocks unchanged. Pattern: [thing] [action] [reason]. Do NOT apply caveman to code, git commits, or structured output fields.' If CAVEMAN_ACTIVE is false, include: 'OFF'}
+
    INSTRUCTIONS:
    1. Read each listed cavekit requirement for full context
    2. Implement the packet as one coherent slice of work
@@ -124,6 +128,12 @@ Once the setup script completes (outputs the ralph prompt), you run the executio
      Skip all three steps if the subagent reported no changes (Claude Code auto-cleans worktrees with no changes). If a merge conflicts, clean up the worktree (`git worktree remove <worktree-path> --force`) before reporting the conflict.
    - Update `context/impl/impl-*.md` with status for each completed task
    - Record any dead ends in `context/impl/dead-ends.md`
+   - Update `context/impl/loop-log.md` with an iteration entry. **If `CAVEMAN_ACTIVE` is true**, compress the loop-log entry to a dense one-liner per task using caveman-speak. Instead of verbose iteration summaries, write compact entries like:
+     ```
+     ### Iteration {N} — {date}
+     - T-{id}: {title} — DONE. Files: {list}. Build P, Tests P. Next: T-{ids}
+     ```
+     The log stays searchable but uses a fraction of the context window. Field names (Task, Status, Files, Validation, Next) can be abbreviated. If `CAVEMAN_ACTIVE` is false, use the standard verbose format.
 
 6. **Tier boundary check** — after updating impl tracking, check whether all tasks in the current tier are now done. If the current tier still has undone tasks, skip this step. If the tier is complete, run the Codex tier gate review (the `TIER_START_REF` was captured in step 1 at the start of this tier):
 

--- a/commands/draft.md
+++ b/commands/draft.md
@@ -17,6 +17,7 @@ Before doing any substantive work:
 1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" summary` and print that exact line once.
 2. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" model exploration` and store it as `EXPLORATION_MODEL`.
 3. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" model reasoning` and store it as `REASONING_MODEL`.
+4. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" caveman-active draft` and treat the result as `CAVEMAN_ACTIVE` (true/false). Draft phase is NOT in the default caveman_phases, so this will typically be false. If true, apply caveman-speak to research agent prompts and internal summaries only — never to kit content, user-facing design proposals, or questions.
 
 Keep the user Q&A in the parent thread. Use `EXPLORATION_MODEL` for helper exploration/research and `REASONING_MODEL` for cavekit generation and review.
 

--- a/commands/inspect.md
+++ b/commands/inspect.md
@@ -17,8 +17,11 @@ Before starting inspection:
 
 1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" summary` and print that exact line once.
 2. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" model reasoning` and treat the result as `REASONING_MODEL`.
+3. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh" caveman-active inspect` and treat the result as `CAVEMAN_ACTIVE` (true/false).
 
 Use `REASONING_MODEL` explicitly for the delegated surveyor and inspector work below.
+
+If `CAVEMAN_ACTIVE` is `true`, your own output (status updates, summaries, reasoning) should use caveman-speak: drop articles, filler, pleasantries — keep technical terms exact and code blocks unchanged. The structured report tables (coverage matrix, findings with P0/P1/P2/P3) stay in normal format. Inject `CAVEMAN MODE: ON` into bp:surveyor and bp:inspector subagent prompts so their status reports are also compressed.
 
 ## Step 1: Gather Context
 

--- a/scripts/bp-config.sh
+++ b/scripts/bp-config.sh
@@ -32,6 +32,8 @@ _bp_config_default() {
     command_gate_blocklist) echo "" ;;
     speculative_review) echo "" ;;
     speculative_review_timeout) echo "" ;;
+    caveman_mode) echo "on" ;;
+    caveman_phases) echo "build,inspect" ;;
     *) echo "" ;;
   esac
 }
@@ -72,11 +74,27 @@ _bp_config_validate() {
       echo "bp_config_set: invalid value '$value' for '$key' (allowed: on off)" >&2
       return 1
       ;;
+    caveman_mode)
+      case "$value" in on|off) return 0 ;; esac
+      echo "bp_config_set: invalid value '$value' for '$key' (allowed: on off)" >&2
+      return 1
+      ;;
+    caveman_phases)
+      local phase
+      local IFS=','
+      for phase in $value; do
+        case "$phase" in build|inspect|draft|architect) ;; *)
+          echo "bp_config_set: invalid phase '$phase' in '$key' (allowed: build,inspect,draft,architect)" >&2
+          return 1
+          ;; esac
+      done
+      return 0
+      ;;
     *) return 0 ;;
   esac
 }
 
-_BP_CONFIG_KEYS="bp_model_preset codex_review codex_model codex_effort tier_gate_mode command_gate command_gate_model command_gate_timeout command_gate_allowlist command_gate_blocklist speculative_review speculative_review_timeout"
+_BP_CONFIG_KEYS="bp_model_preset codex_review codex_model codex_effort tier_gate_mode command_gate command_gate_model command_gate_timeout command_gate_allowlist command_gate_blocklist speculative_review speculative_review_timeout caveman_mode caveman_phases"
 
 bp_global_config_path() {
   if [[ -n "${BP_GLOBAL_CONFIG_PATH:-}" ]]; then
@@ -329,6 +347,24 @@ bp_config_model() {
   esac
 }
 
+bp_config_caveman_active() {
+  local phase="${1:?bp_config_caveman_active: phase required}"
+  local mode phases
+
+  mode="$(bp_config_get caveman_mode on)"
+  if [[ "$mode" != "on" ]]; then
+    echo "false"
+    return 0
+  fi
+
+  phases="$(bp_config_get caveman_phases build,inspect)"
+  if echo ",$phases," | grep -q ",$phase,"; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 bp_config_summary_line() {
   local preset reasoning execution exploration
 
@@ -337,7 +373,10 @@ bp_config_summary_line() {
   execution="$(bp_config_model execution)" || return 1
   exploration="$(bp_config_model exploration)" || return 1
 
-  echo "Cavekit preset: ${preset} (reasoning=${reasoning}, execution=${execution}, exploration=${exploration})"
+  local caveman_mode
+  caveman_mode="$(bp_config_get caveman_mode on)"
+
+  echo "Cavekit preset: ${preset} (reasoning=${reasoning}, execution=${execution}, exploration=${exploration}, caveman=${caveman_mode})"
 }
 
 bp_config_show() {
@@ -351,6 +390,10 @@ bp_config_show() {
   execution="$(bp_config_model execution)" || return 1
   exploration="$(bp_config_model exploration)" || return 1
 
+  local caveman_mode caveman_phases
+  caveman_mode="$(bp_config_get caveman_mode on)"
+  caveman_phases="$(bp_config_get caveman_phases build,inspect)"
+
   cat <<EOF
 bp_model_preset=${preset}
 bp_model_preset_source=${preset_source}
@@ -358,6 +401,8 @@ bp_model_preset_source_path=${preset_source_path}
 reasoning_model=${reasoning}
 execution_model=${execution}
 exploration_model=${exploration}
+caveman_mode=${caveman_mode}
+caveman_phases=${caveman_phases}
 project_config=$(bp_project_config_path)
 global_config=$(bp_global_config_path)
 EOF
@@ -420,9 +465,10 @@ bp_config_main() {
     show) bp_config_show ;;
     summary) bp_config_summary_line ;;
     presets) bp_config_presets ;;
+    caveman-active) bp_config_caveman_active "$@" ;;
     help|--help|-h)
       cat <<'EOF'
-Usage: bp-config.sh {init|get|set|list|path|source|source-path|effective-preset|model|show|summary|presets}
+Usage: bp-config.sh {init|get|set|list|path|source|source-path|effective-preset|model|show|summary|presets|caveman-active}
   init                              Create/backfill global and project config files
   get <key> [default]               Read an effective config value
   set <key> <val> [--global|--project]
@@ -436,6 +482,7 @@ Usage: bp-config.sh {init|get|set|list|path|source|source-path|effective-preset|
   show                              Print effective preset, source, and resolved models
   summary                           Print a one-line preset summary
   presets                           Print the built-in preset table
+  caveman-active <phase>            Check if caveman mode is active for a phase (build|inspect|draft|architect)
 EOF
       ;;
     *)

--- a/scripts/codex-design-challenge.sh
+++ b/scripts/codex-design-challenge.sh
@@ -29,7 +29,35 @@ _BP_DESIGN_CHALLENGE_LOADED=1
 # ── T-301: Design Challenge Prompt Template ───────────────────────────
 
 _bp_design_challenge_prompt() {
-  cat <<'PROMPT'
+  local caveman_active="false"
+  if type bp_config_caveman_active &>/dev/null; then
+    caveman_active="$(bp_config_caveman_active build)"
+  fi
+
+  if [[ "$caveman_active" == "true" ]]; then
+    cat <<'PROMPT'
+Senior architect. Adversarial design review of cavekit specs. CHALLENGE design, not rubber-stamp.
+
+Review all kits as whole system. Design-level concerns only:
+
+1. **Domain Decomposition** — boundaries right? Over/under-scoped? Better decomposition possible?
+2. **Requirement Coverage** — missing reqs? Gaps between domains? Cross-refs cover all interactions?
+3. **Ambiguity** — criteria vague? Checkbox reqs? Implementer know exactly what to build?
+4. **Scope** — domains over/under-scoped? Implicit assumptions?
+5. **Cross-Domain Coherence** — domains fit together? Contradictions? Hidden circular deps?
+
+Rules: NO impl feedback. MUST propose alternative decomposition if better exists. Reference cavekit files + R-numbers.
+
+Output: one row per finding in markdown table: Category, Severity, Cavekit, Requirement, Description
+Category: decomposition|coverage|ambiguity|scope|assumption
+Severity: critical|advisory
+No issues = NO_ISSUES
+
+## Kits to Review
+
+PROMPT
+  else
+    cat <<'PROMPT'
 You are a senior software architect performing an adversarial design review of cavekit specifications. Your job is to CHALLENGE the design, not rubber-stamp it.
 
 Review all kits as a whole system. Focus exclusively on design-level concerns:
@@ -78,6 +106,7 @@ If you find no issues at all, output exactly: NO_ISSUES
 ## Kits to Review
 
 PROMPT
+  fi
 }
 
 # ── T-302: Challenge Output Parser ────────────────────────────────────

--- a/scripts/codex-design-challenge.sh
+++ b/scripts/codex-design-challenge.sh
@@ -31,7 +31,7 @@ _BP_DESIGN_CHALLENGE_LOADED=1
 _bp_design_challenge_prompt() {
   local caveman_active="false"
   if type bp_config_caveman_active &>/dev/null; then
-    caveman_active="$(bp_config_caveman_active build)"
+    caveman_active="$(bp_config_caveman_active draft)"
   fi
 
   if [[ "$caveman_active" == "true" ]]; then

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -21,7 +21,20 @@ else
   bp_config_get() { echo "${2:-}"; }
 fi
 
-REVIEW_PROMPT='You are a senior engineer performing adversarial code review. Review the following diff for bugs, security issues, logic errors, and spec violations. For each finding output exactly one row in a markdown table with columns: Severity, File, Line, Description. Severity must be one of P0 (critical), P1 (high), P2 (medium), P3 (low). If no issues found, output exactly the word NO_FINDINGS on its own line and nothing else.'
+_bp_build_review_prompt() {
+  local caveman_active="false"
+  if type bp_config_caveman_active &>/dev/null; then
+    caveman_active="$(bp_config_caveman_active build)"
+  fi
+
+  if [[ "$caveman_active" == "true" ]]; then
+    echo 'Senior engineer. Adversarial code review. Check diff for bugs, security holes, logic errors, spec violations. Each finding = one row in markdown table: Severity, File, Line, Description. Severity: P0 (critical) | P1 (high) | P2 (medium) | P3 (low). No issues found = output NO_FINDINGS alone.'
+  else
+    echo 'You are a senior engineer performing adversarial code review. Review the following diff for bugs, security issues, logic errors, and spec violations. For each finding output exactly one row in a markdown table with columns: Severity, File, Line, Description. Severity must be one of P0 (critical), P1 (high), P2 (medium), P3 (low). If no issues found, output exactly the word NO_FINDINGS on its own line and nothing else.'
+  fi
+}
+
+REVIEW_PROMPT="$(_bp_build_review_prompt)"
 
 # ── Main entry point ───────────────────────────────────────────────────
 

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: caveman
+description: |
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  Integrated into Cavekit: enabled by default for build, inspect, and subagent phases
+  via caveman_mode config. See scripts/bp-config.sh for caveman_mode and caveman_phases.
+---
+
+# Caveman Mode
+
+## Core Rule
+
+Respond like smart caveman. Cut articles, filler, pleasantries. Keep all technical substance.
+
+Default intensity: **full**. Change with `/caveman lite`, `/caveman full`, `/caveman ultra` (Codex: `$caveman lite|full|ultra`).
+
+## Grammar
+
+- Drop articles (a, an, the)
+- Drop filler (just, really, basically, actually, simply)
+- Drop pleasantries (sure, certainly, of course, happy to)
+- Short synonyms (big not extensive, fix not "implement a solution for")
+- No hedging (skip "it might be worth considering")
+- Fragments fine. No need full sentence
+- Technical terms stay exact. "Polymorphism" stays "polymorphism"
+- Code blocks unchanged. Caveman speak around code, not in code
+- Error messages quoted exact. Caveman only for explanation
+
+## Pattern
+
+```
+[thing] [action] [reason]. [next step].
+```
+
+Not:
+> Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...
+
+Yes:
+> Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:
+
+## Examples
+
+**User:** Why is my React component re-rendering?
+
+**Normal (69 tokens):** "The reason your React component is re-rendering is likely because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time, which triggers a re-render. I'd recommend using useMemo to memoize the object."
+
+**Caveman (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+
+---
+
+**User:** How do I set up a PostgreSQL connection pool?
+
+**Caveman:**
+```
+Use `pg` pool:
+```
+```js
+const pool = new Pool({
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+})
+```
+```
+max = concurrent connections. Keep under DB limit. idleTimeout kill stale conn.
+```
+
+## Intensity Levels
+
+### Lite — trim the fat
+
+Professional tone, just no fluff. Grammar stays intact.
+
+- Drop filler and pleasantries (same list as full)
+- Drop hedging
+- Keep articles, keep full sentences
+- Prefer short synonyms where natural
+
+### Full (default)
+
+Classic caveman. Rules from Grammar section above apply.
+
+### Ultra — maximum grunt
+
+Telegraphic. Every word earn its place or die.
+
+- All full rules, plus:
+- Abbreviate common terms (DB, auth, config, req, res, fn, impl)
+- Strip conjunctions where possible
+- One word answer when one word enough
+- Arrow notation for causality (X -> Y)
+
+## Intensity Examples
+
+**User:** Why is my React component re-rendering?
+
+**Lite:** "Your component re-renders because you create a new object reference each render. Inline object props fail shallow comparison every time. Wrap it in `useMemo`."
+
+**Full:** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+
+**Ultra:** "Inline obj prop -> new ref -> re-render. `useMemo`."
+
+---
+
+**User:** Explain database connection pooling.
+
+**Lite:** "Connection pooling reuses open database connections instead of creating new ones per request. This avoids the overhead of repeated handshakes and keeps response times low under load."
+
+**Full:** "Pool reuse open DB connections. No new connection per request. Skip repeated handshake overhead. Response time stay low under load."
+
+**Ultra:** "Pool = reuse DB conn. Skip handshake overhead -> fast under load."
+
+## Boundaries
+
+- Code: write normal. Caveman English only
+- Git commits: normal
+- PR descriptions: normal
+- User say "stop caveman" or "normal mode": revert immediately
+- Intensity level persist until changed or session end
+
+## Cavekit Integration
+
+When caveman_mode is enabled in Cavekit config (on by default), caveman-speak is automatically applied to:
+
+- **Build phase** (`/bp:build`): wave logs, iteration summaries, task status reports
+- **Inspect phase** (`/bp:inspect`): gap analysis summaries, peer review output
+- **Subagent communication**: all inter-agent status reports, merge summaries, wave completions
+- **Loop logging**: compressed entries in `context/impl/loop-log.md`
+- **Codex prompt framing**: setup text around review prompts (not the code or structured findings)
+
+Caveman is NOT applied to:
+- **Draft phase** (`/bp:draft`): kits are human-reviewed specs, need normal prose
+- **Architect phase** (`/bp:architect`): build sites are source of truth, need clarity
+- **Code blocks**: code is always written normally
+- **Spec artifacts**: kits, build sites, DESIGN.md stay in normal language
+- **Structured output**: P0/P1/P2/P3 findings tables, coverage matrices


### PR DESCRIPTION
## Summary

Introduces "caveman mode," a new skill that reduces token usage by ~75% through ultra-compressed communication while maintaining full technical accuracy. Caveman mode can be toggled on/off and configured to apply to specific build phases (build, inspect, draft, architect).

## Key Changes

- **New skill: `skills/caveman/SKILL.md`** — Comprehensive documentation of caveman mode with:
  - Core grammar rules (drop articles, filler, pleasantries; keep technical terms exact)
  - Three intensity levels: lite (professional trim), full (default), ultra (telegraphic)
  - Detailed examples showing token savings (e.g., 69 → 19 tokens for React re-render explanation)
  - Boundaries (code blocks, git commits, PR descriptions stay normal; spec artifacts exempt)
  - Cavekit integration details

- **Configuration system updates** (`scripts/bp-config.sh`):
  - Added `caveman_mode` config key (on/off, default: on)
  - Added `caveman_phases` config key (comma-separated phases: build, inspect, draft, architect; default: build,inspect)
  - New `bp_config_caveman_active <phase>` function to check if caveman mode is active for a given phase
  - Validation for both new config keys
  - Updated config summary and show output to include caveman settings

- **Prompt integration**:
  - `scripts/codex-review.sh`: Review prompt now conditionally uses caveman-speak when active for build phase
  - `scripts/codex-design-challenge.sh`: Design challenge prompt uses caveman-speak when active for build phase

- **Command updates**:
  - `commands/build.md`: Added step to check `caveman-active build` and instructions for applying caveman-speak to wave logs, iteration summaries, and status reports
  - `commands/inspect.md`: Added step to check `caveman-active inspect` with similar guidance
  - `commands/architect.md` & `commands/draft.md`: Added config summary step (caveman not applied to these phases by default)
  - `agents/task-builder.md`: Added caveman mode awareness for task execution

- **Documentation**:
  - `README.md`: Updated skill count (15 → 16) and added caveman mode to configuration table with descriptions

## Implementation Details

- Caveman mode is **enabled by default** (`caveman_mode=on`) and applies to **build and inspect phases** by default (`caveman_phases=build,inspect`)
- The feature respects phase boundaries: draft and architect phases are exempt by default, allowing human-reviewed specs to remain in normal prose
- Code blocks, git commits, PR descriptions, and structured output (P0/P1/P2/P3 tables) are never affected
- Intensity levels persist within a session and can be changed via `/caveman lite|full|ultra` or Codex `$caveman lite|full|ultra`
- Integration is non-breaking: existing workflows continue unchanged; caveman mode is opt-out via config

https://claude.ai/code/session_018MDR9vb5fsAKp4c2LtxYb5