### PR TITLE
Make Cavekit Codex-first

### DIFF
--- a/.agents/skills/ck-check/SKILL.md
+++ b/.agents/skills/ck-check/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ck-check
+description: Run the Cavekit inspection phase. Use when the user wants built behavior compared against intended behavior, including gaps, review findings, and revision guidance.
+---
+
+Invoke this skill explicitly with `$ck-check`.
+
+This is the Codex-first equivalent of upstream `/ck:check`.
+
+Use this skill when:
+- A build cycle has completed and the result needs inspection.
+- The user wants gaps, regressions, or requirement misses surfaced.
+- The project needs a Codex-first review pass tied back to the kits.

--- a/.agents/skills/ck-design/SKILL.md
+++ b/.agents/skills/ck-design/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ck-design
+description: Run the Cavekit design-system phase. Use when the user wants to create, import, audit, or revise DESIGN.md before implementation.
+---
+
+Invoke this skill explicitly with `$ck-design`.
+
+This is the Codex-first equivalent of upstream `/ck:design`.
+
+Use this skill when:
+- The user wants to define or revise the project design system.
+- The project needs a DESIGN.md imported from an existing product or codebase.
+- UI work should be constrained by a stable visual system before build tasks begin.

--- a/.agents/skills/ck-make/SKILL.md
+++ b/.agents/skills/ck-make/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ck-make
+description: Run the Cavekit build phase. Use when the user wants to execute the build site task loop with validation, progress tracking, and optional review gates.
+---
+
+Invoke this skill explicitly with `$ck-make`.
+
+This is the Codex-first equivalent of upstream `/ck:make`.
+
+Use this skill when:
+- A build site already exists and implementation should begin.
+- The user wants the next unblocked Cavekit tasks executed.
+- A focused site or domain should be built incrementally.

--- a/.agents/skills/ck-map/SKILL.md
+++ b/.agents/skills/ck-map/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ck-map
+description: Run the Cavekit map phase. Use when the user wants to turn kits into a dependency-ordered build site with tasks and coverage mapping.
+---
+
+Invoke this skill explicitly with `$ck-map`.
+
+This is the Codex-first equivalent of upstream `/ck:map`.
+
+Use this skill when:
+- Kits already exist and the next step is execution planning.
+- The user wants dependencies, tiers, and task boundaries made explicit.
+- A subset of kits or domains needs a focused build site.

--- a/.agents/skills/ck-research/SKILL.md
+++ b/.agents/skills/ck-research/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ck-research
+description: Run the Cavekit research phase. Use when the user wants codebase and web research synthesized into a brief before sketching or revising a design.
+---
+
+Invoke this skill explicitly with `$ck-research`.
+
+This is the Codex-first equivalent of upstream `/ck:research`.
+
+Use this skill when:
+- The user wants a grounded research brief before writing kits.
+- The project needs library, architecture, or implementation landscape research.
+- A brownfield codebase needs reconnaissance before planning.
+
+Expected behavior:
+- Explore the local codebase when relevant.
+- Use current documentation and web sources when freshness matters.
+- Produce or update a research brief under `context/refs/` when the workflow calls for it.
+- Keep the output aligned with Cavekit methodology and downstream kit generation.

--- a/.agents/skills/ck-sketch/SKILL.md
+++ b/.agents/skills/ck-sketch/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ck-sketch
+description: Run the Cavekit sketch phase. Use when the user wants to turn an idea, reference set, or existing codebase into Cavekit kits with numbered requirements and criteria.
+---
+
+Invoke this skill explicitly with `$ck-sketch`.
+
+This is the Codex-first equivalent of upstream `/ck:sketch`.
+
+Use this skill when:
+- The user wants to draft kits from a new product idea.
+- The user wants to derive kits from existing code.
+- The project needs requirements and acceptance criteria before mapping tasks.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/JuliusBrussee/cavekit/stargazers"><img src="https://img.shields.io/github/stars/JuliusBrussee/cavekit?style=flat&color=yellow" alt="Stars"></a>
   <a href="https://github.com/JuliusBrussee/cavekit/commits/main"><img src="https://img.shields.io/github/last-commit/JuliusBrussee/cavekit?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/JuliusBrussee/cavekit?style=flat" alt="License"></a>
-  <a href="https://docs.anthropic.com/en/docs/claude-code"><img src="https://img.shields.io/badge/Claude_Code-plugin-blueviolet" alt="Claude Code Plugin"></a>
+  <a href="https://developers.openai.com/codex/concepts/customization#skills"><img src="https://img.shields.io/badge/Codex_CLI-skills-green" alt="Codex CLI Skills"></a>
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that turns natural language into **specs**, specs into **parallel build plans**, and build plans into **working software** — with automated iteration, validation, and dual-model adversarial review.
+A Codex CLI workflow that turns natural language into **specs**, specs into **parallel build plans**, and build plans into **working software** — with automated iteration, validation, and Codex-first adversarial review.
 
 You describe what you want. Cavekit writes the contract. Agents build from the contract. Every line of code traces to a requirement. Every requirement has acceptance criteria. Nothing gets lost, nothing gets guessed.
 
@@ -63,13 +63,13 @@ The agent guessed what you wanted.
 ### With Cavekit
 
 ```
-> /ck:sketch
+> $ck-sketch
   4 kits, 22 requirements, 69 criteria
 
-> /ck:map
+> $ck-map
   34 tasks across 5 dependency tiers
 
-> /ck:make
+> $ck-make
   18 iterations — each validated against
   the spec before committing
 
@@ -108,7 +108,7 @@ Instead of "prompt and pray," Cavekit puts a **specification layer** between you
 ```
                         ┌─── Task 1 ─── Agent A ───┐
                         │                           │
-You ── /ck:sketch ──► Kits ── /ck:map ──► Build Site ──┤─── Task 2 ─── Agent B ───┤──► done
+You ── $ck-sketch ──► Kits ── $ck-map ──► Build Site ──┤─── Task 2 ─── Agent B ───┤──► done
                         │                           │
                         └─── Task 3 ─── Agent C ───┘
 ```
@@ -122,27 +122,27 @@ Spec is the product. Code is the derivative.
 ## Install
 
 ```bash
-git clone https://github.com/JuliusBrussee/cavekit.git ~/.cavekit
+git clone https://github.com/astrawinski/cavekit.git ~/.cavekit
 cd ~/.cavekit && ./install.sh
 ```
 
-Registers the plugin with Claude Code, syncs into Codex marketplace, installs the `cavekit` CLI. Restart Claude Code after installing.
+Installs the `cavekit` CLI, links the repo into local Codex discovery paths, and exposes repo-local Cavekit skills from `.agents/skills`.
 
-**Requires:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), git, macOS/Linux.
+**Requires:** [Codex CLI](https://developers.openai.com/codex/concepts/customization#skills), git, macOS/Linux.
 
-**Optional:** [Codex](https://github.com/openai/codex) (`npm install -g @openai/codex`) — adds adversarial review. Cavekit works without it. Codex makes it significantly harder to ship flawed specs and broken code.
+**Optional:** tmux for parallel session orchestration with `cavekit --monitor`.
 
 ---
 
 ## How It Works
 
-Four phases. Each one a slash command.
+Four phases. Each one a Codex skill.
 
 ```
   RESEARCH         DRAFT            ARCHITECT           BUILD              INSPECT
   ────────         ─────            ─────────           ─────              ───────
   (optional)       "What are we     Break into tasks,   Auto-parallel:     Gap analysis:
-  Multi-agent       building?"      map dependencies,    /ck:make          built vs.
+  Multi-agent       building?"      map dependencies,    $ck-make          built vs.
   codebase +                        organize into        groups work        intended.
   web research     Produces:        tiered build site    into adaptive      Peer review.
                    kits with        + dependency graph   subagent packets   Trace to specs.
@@ -156,42 +156,42 @@ Four phases. Each one a slash command.
 ### 0. Research — ground the design (optional)
 
 ```
-/ck:research "build a C+ compiler"
+$ck-research "build a C+ compiler"
 ```
 
 Dispatches 2–8 parallel subagents to explore the codebase and search the web for best practices, library landscape, reference implementations, and common pitfalls. A synthesizer agent cross-validates findings and produces a research brief in `context/refs/`.
 
-### /ck:design — establish the design system
+### $ck-design — establish the design system
 
 ```
-/ck:design
+$ck-design
 ```
 
 Creates or imports a **DESIGN.md** design system — a cross-cutting constraint layer enforced across the entire pipeline. Every kit references its design tokens, every task carries a Design Ref, every build result is audited for violations.
 
 | Sub-command | What it does |
 |------------|-------------|
-| `/ck:design create` | Generate new DESIGN.md via guided Q&A |
-| `/ck:design import` | Extract DESIGN.md from existing codebase |
-| `/ck:design audit` | Check implementation against DESIGN.md |
-| `/ck:design update` | Revise DESIGN.md, log to changelog |
+| `$ck-design create` | Generate new DESIGN.md via guided Q&A |
+| `$ck-design import` | Extract DESIGN.md from existing codebase |
+| `$ck-design audit` | Check implementation against DESIGN.md |
+| `$ck-design update` | Revise DESIGN.md, log to changelog |
 
 ### 1. Draft — define the what
 
 ```
-/ck:sketch
+$ck-sketch
 ```
 
 Describe what you're building in natural language. Cavekit decomposes it into **domain kits** — structured documents with numbered requirements (R1, R2, ...) and testable acceptance criteria. Stack-independent. Human-readable.
 
 After internal review, kits go to Codex for a [design challenge](#design-challenge--catch-spec-flaws-before-building) — adversarial review that catches decomposition flaws, missing requirements, and ambiguous criteria before any code is written.
 
-For existing codebases: `/ck:sketch --from-code` reverse-engineers kits from your code and identifies gaps.
+For existing codebases: `$ck-sketch --from-code` reverse-engineers kits from your code and identifies gaps.
 
 ### 2. Architect — plan the order
 
 ```
-/ck:map
+$ck-map
 ```
 
 Reads all kits. Breaks requirements into tasks. Maps dependencies. Organizes into a **tiered build site** — a dependency graph where Tier 0 has no deps, Tier 1 depends only on Tier 0, and so on. Includes a **Coverage Matrix** mapping every acceptance criterion to its task(s). Nothing specified gets lost in translation.
@@ -199,7 +199,7 @@ Reads all kits. Breaks requirements into tasks. Maps dependencies. Organizes int
 ### 3. Build — run the loop
 
 ```
-/ck:make
+$ck-make
 ```
 
 Pre-flight coverage check validates all acceptance criteria are covered. Then the loop runs:
@@ -235,7 +235,7 @@ Post-flight verification cross-references what was built against original kits. 
 ### 4. Inspect — verify the result
 
 ```
-/ck:check
+$ck-check
 ```
 
 Gap analysis: built vs. specified. Peer review: bugs, security, missed requirements. Everything traced back to kit requirements.
@@ -247,20 +247,20 @@ Gap analysis: built vs. specified. Peer review: bugs, security, missed requireme
 **Greenfield:**
 
 ```
-> /ck:sketch
+> $ck-sketch
 What are you building?
 
 > A REST API for task management. Users, projects, tasks
   with priorities and due dates. PostgreSQL.
 
 Created 4 kits (22 requirements, 69 acceptance criteria)
-Next: /ck:map
+Next: $ck-map
 
-> /ck:map
+> $ck-map
 Generated build site: 34 tasks, 5 tiers
-Next: /ck:make
+Next: $ck-make
 
-> /ck:make
+> $ck-make
 Loop activated — 34 tasks, 20 max iterations.
 ...
 All tasks done. Build passes. Tests pass.
@@ -270,14 +270,14 @@ CAVEKIT COMPLETE — 34 tasks in 18 iterations.
 **Existing codebase:**
 
 ```
-> /ck:sketch --from-code
+> $ck-sketch --from-code
 Exploring codebase... Next.js 14, Prisma, NextAuth.
 Created 6 kits — 4 requirements are gaps (not yet implemented).
 
-> /ck:map --filter collaboration
+> $ck-map --filter collaboration
 Generated build site: 8 tasks, 3 tiers
 
-> /ck:make
+> $ck-make
 CAVEKIT COMPLETE — 8 tasks in 8 iterations.
 ```
 
@@ -287,7 +287,7 @@ See [example.md](example.md) for full annotated sessions.
 
 ## Parallel Execution
 
-`/ck:make` parallelizes automatically. Multiple ready tasks get grouped into coherent work packets and dispatched concurrently.
+`$ck-make` parallelizes automatically. Multiple ready tasks get grouped into coherent work packets and dispatched concurrently.
 
 ```
 ═══ Wave 1 ═══
@@ -325,14 +325,14 @@ Circuit breakers prevent infinite loops: 3 test failures → task BLOCKED, all b
 
 ## Codex Adversarial Review
 
-Cavekit uses [Codex](https://github.com/openai/codex) as an adversarial reviewer — a second model with different training and different blind spots. Catches things Claude cannot see in its own output. Operates at three levels:
+Cavekit uses [Codex](https://github.com/openai/codex) as an adversarial reviewer — a second pass with different blind spots from the main build loop. Operates at three levels:
 
 ### Design Challenge — catch spec flaws before building
 
 After kits are drafted and internally reviewed, the full set goes to Codex:
 
 ```
-Claude drafts            Kit set             Codex challenges         User reviews
+Builder drafts           Kit set             Codex challenges         User reviews
 kits ──────► reviewer approves ──────► the design ──────► kits + findings
 ```
 
@@ -373,7 +373,7 @@ Fix cycle runs up to 2 iterations per tier. After that, advances with warning. N
 
 ### Speculative Review — eliminate gate latency
 
-Codex reviews the *previous* tier in the background while Claude builds the *current* tier:
+Codex reviews the *previous* tier in the background while the active build loop works on the *current* tier:
 
 ```
 Tier 0 complete ───────────────────────────► Tier 1 complete
@@ -404,7 +404,7 @@ Codex classifies ──► safe / warn / block
 Verdict cache ──► normalized pattern → reuse verdict
 ```
 
-Integrates with Claude Code's permission system. Cached per session. Falls back to static rules when Codex is unavailable — never blocks solely because classifier is unreachable.
+Integrates with the active agent approval flow. Cached per session. Falls back to static rules when Codex is unavailable — never blocks solely because the classifier is unreachable.
 
 ### Graceful Degradation
 
@@ -452,39 +452,39 @@ Settings live in two places:
 | `fast` | `sonnet` | `sonnet` | `haiku` |
 
 ```
-/ck:config                      # show current
-/ck:config preset balanced      # change preset
-/ck:config preset fast --global # change default
+$ck-config                      # show current
+$ck-config preset balanced      # change preset
+$ck-config preset fast --global # change default
 ```
 
 ---
 
 ## Commands
 
-### Claude Code
+### Codex Skills
 
 | Command | Phase | What it does |
 |---------|-------|-------------|
-| `/ck:research` | Research | Multi-agent codebase + web research, produces brief |
-| `/ck:design` | Design | Create, import, audit, or update DESIGN.md |
-| `/ck:sketch` | Draft | Decompose requirements into domain kits |
-| `/ck:map` | Architect | Generate tiered build site from kits |
-| `/ck:make` | Build | Auto-parallel build with validation loop |
-| `/ck:check` | Inspect | Gap analysis + peer review against kits |
-| `/ck:config` | — | Show or update execution preset |
-| `/ck:judge` | — | Standalone Codex adversarial review on diff |
-| `/ck:progress` | — | Check build site progress |
-| `/ck:scan` | — | Compare built vs. intended |
-| `/ck:revise` | — | Trace manual fixes back into kits |
-| `/ck:help` | — | Usage guide |
+| `$ck-research` | Research | Multi-agent codebase + web research, produces brief |
+| `$ck-design` | Design | Create, import, audit, or update DESIGN.md |
+| `$ck-sketch` | Draft | Decompose requirements into domain kits |
+| `$ck-map` | Architect | Generate tiered build site from kits |
+| `$ck-make` | Build | Auto-parallel build with validation loop |
+| `$ck-check` | Inspect | Gap analysis + peer review against kits |
+| `$ck-config` | — | Show or update execution preset |
+| `$ck-judge` | — | Standalone Codex adversarial review on diff |
+| `$ck-progress` | — | Check build site progress |
+| `$ck-scan` | — | Compare built vs. intended |
+| `$ck-revise` | — | Trace manual fixes back into kits |
+| `$ck-help` | — | Usage guide |
 
 ### CLI
 
 | Command | What it does |
 |---------|-------------|
-| `cavekit monitor` | Interactive launcher — pick build sites, launch in tmux |
-| `cavekit status` | Show build site progress |
-| `cavekit kill` | Stop all sessions, clean up worktrees |
+| `cavekit --monitor` | Interactive launcher — pick build sites, launch in tmux |
+| `cavekit --status` | Show build site progress |
+| `cavekit --kill` | Stop all sessions, clean up worktrees |
 | `cavekit version` | Print version |
 | `cavekit debug` | Show state file path and version |
 | `cavekit reset` | Clear persisted state |
@@ -525,7 +525,7 @@ Cavekit applies the **scientific method** to AI-generated code. LLMs are non-det
 | **Implementation tracking** | Lab notebook — what was tried, what worked, what failed |
 | **Revision** | Update the hypothesis — trace bugs back to kits |
 
-Ships with 9 specialized agents (including **design-reviewer** for UI validation against DESIGN.md), a multi-agent research system, and 15 skills covering the full methodology. With Codex, operates as a **dual-model architecture** — Claude builds, Codex reviews — catching errors single-model self-review cannot.
+Ships with 9 specialized agents (including **design-reviewer** for UI validation against DESIGN.md), a multi-agent research system, and 15 skills covering the full methodology. With Codex, Cavekit can layer review on top of the build loop to catch errors a single pass can miss.
 
 <details>
 <summary><strong>All 16 skills</strong></summary>
@@ -575,7 +575,7 @@ If cavekit save you mass debug time — leave star.
 
 ## Also by Julius Brussee
 
-- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. Bundled in Cavekit and enabled by default for build/inspect phases. Standalone install: `npx skills add JuliusBrussee/caveman`
+- **[Caveman](https://github.com/JuliusBrussee/caveman)** — token-compressed skill style that cuts output volume significantly while preserving signal. Bundled in Cavekit for build/inspect phases.
 - **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
 
 ## License

--- a/cmd/cavekit/main.go
+++ b/cmd/cavekit/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -26,6 +27,8 @@ func main() {
 	switch cmd {
 	case "monitor", "":
 		runMonitor()
+	case "hello":
+		os.Exit(runHello(os.Args[2:], os.Stdout, os.Stderr))
 	case "status":
 		runStatus()
 	case "kill":
@@ -38,14 +41,24 @@ func main() {
 		runReset()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
-		fmt.Fprintln(os.Stderr, "usage: cavekit [monitor|status|kill|version|debug|reset]")
+		fmt.Fprintln(os.Stderr, "usage: cavekit [monitor|hello|status|kill|version|debug|reset]")
 		os.Exit(1)
 	}
 }
 
+func runHello(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "usage: cavekit hello <name>")
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Hello, %s!\n", args[0])
+	return 0
+}
+
 func runMonitor() {
 	// Parse flags
-	program := "claude"
+		program := "codex"
 	autoYes := false
 	for i, arg := range os.Args {
 		if (arg == "--program" || arg == "-p") && i+1 < len(os.Args) {

--- a/commands/check.md
+++ b/commands/check.md
@@ -4,11 +4,11 @@ description: "Inspect the last loop: gap analysis against kits + peer review cod
 argument-hint: "[--filter PATTERN]"
 ---
 
-> **Note:** `/bp:inspect`, `/ck:inspect`, `/bp:check` are deprecated aliases. Use `/ck:check` instead.
+> **Note:** `$bp-inspect`, `$ck-inspect`, `$bp-check` are deprecated aliases. Use `$ck-check` instead.
 
 # Cavekit Inspect — Post-Loop Analysis
 
-Run this after `/ck:make` completes (or is stopped). It does two things:
+Run this after `$ck-make` completes (or is stopped). It does two things:
 
 1. **Gap analysis** — compares what was built against what the kits require
 2. **Peer review** — finds bugs, security issues, and quality problems in the code that was written
@@ -38,7 +38,7 @@ Read these files to understand what happened:
 7. **Design system** — read `DESIGN.md` at project root if it exists (for design compliance checking in Steps 2-3)
 
 If no impl tracking or loop log exists, tell the user:
-> No loop artifacts found. Run `/ck:make` first, then `/ck:check` after it completes.
+> No loop artifacts found. Run `$ck-make` first, then `$ck-check` after it completes.
 
 ## Step 2: Gap Analysis
 
@@ -200,8 +200,8 @@ Present this to the user:
 ## Recommended Next Steps
 1. {highest priority action}
 2. {next action}
-3. {if gaps exist: run `/ck:make` again to address remaining work}
-4. {if cavekit gaps found: kits will be updated below, then `/ck:map` + `/ck:make`}
+3. {if gaps exist: run `$ck-make` again to address remaining work}
+4. {if cavekit gaps found: kits will be updated below, then `$ck-map` + `$ck-make`}
 ```
 
 ## Step 5: Revise
@@ -242,7 +242,7 @@ If new requirements were added to kits, add corresponding tasks to the site:
 
 ### Restore Archived Impl Tracking
 
-If the verdict is **REVISE** or **REJECT** and `context/impl/` has no `impl-*.md` files (they were archived by a previous `/ck:make` run), restore them so the next build cycle knows which tasks are already done:
+If the verdict is **REVISE** or **REJECT** and `context/impl/` has no `impl-*.md` files (they were archived by a previous `$ck-make` run), restore them so the next build cycle knows which tasks are already done:
 
 1. Find the most recent archive: `ls -td context/impl/archive/*/ 2>/dev/null | head -1`
 2. If found, copy all `impl-*.md` files (NOT `loop-log.md` or `peer-review-findings.md`) back to `context/impl/`:
@@ -257,7 +257,7 @@ If the verdict is **REVISE** or **REJECT** and `context/impl/` has no `impl-*.md
    ```
 3. Report the restoration to the user
 
-This ensures the next `/ck:make` cycle can compute the correct frontier (skipping already-done tasks).
+This ensures the next `$ck-make` cycle can compute the correct frontier (skipping already-done tasks).
 
 ### Update Impl Tracking
 
@@ -280,7 +280,7 @@ last_edited: "{CURRENT_DATE_UTC}"
 | F-002: {title} | P1 | {path} | NEW |
 ```
 
-These findings will be picked up by the next `/ck:make` loop — the build prompt reads impl tracking and prioritizes P0 issues first.
+These findings will be picked up by the next `$ck-make` loop — the build prompt reads impl tracking and prioritizes P0 issues first.
 
 ### Report What Changed
 
@@ -302,5 +302,5 @@ After revision, tell the user:
 ### Findings Logged
 {n} findings written to context/impl/impl-review-findings.md
 
-Ready for next cycle: `/ck:make`
+Ready for next cycle: `$ck-make`
 ```

--- a/commands/config.md
+++ b/commands/config.md
@@ -5,7 +5,7 @@ argument-hint: "[list | preset <expensive|quality|balanced|fast> [--global]]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)"]
 ---
 
-> **Note:** `/bp:config` is deprecated and will be removed in a future version. Use `/ck:config` instead.
+> **Note:** `$bp-config` is deprecated and will be removed in a future version. Use `$ck-config` instead.
 
 # Cavekit Config — Execution Presets
 
@@ -13,13 +13,13 @@ Use this command to inspect or change the Cavekit execution preset that maps tas
 
 ## Supported Usage
 
-- `/ck:config`
+- `$ck-config`
   Show the effective preset, resolved models, and where the value came from.
-- `/ck:config list`
+- `$ck-config list`
   Show the built-in presets and their model mappings.
-- `/ck:config preset <name>`
+- `$ck-config preset <name>`
   Set the project override in `.cavekit/config`.
-- `/ck:config preset <name> --global`
+- `$ck-config preset <name> --global`
   Set the user-level default in `~/.cavekit/config`.
 
 If the arguments do not match one of those forms, show this usage summary and stop.

--- a/commands/design.md
+++ b/commands/design.md
@@ -4,7 +4,7 @@ description: "Create or update the project's DESIGN.md — the visual design sys
 argument-hint: "[--import <name>] [--from-site <url>] [--audit] [--section <1-9>]"
 ---
 
-> **Note:** `/bp:design` is deprecated and will be removed in a future version. Use `/ck:design` instead.
+> **Note:** `$bp-design` is deprecated and will be removed in a future version. Use `$ck-design` instead.
 
 # Cavekit Design — Create or Update DESIGN.md
 
@@ -42,9 +42,9 @@ Extract from `$ARGUMENTS`:
 - `--section <1-9>` → **Update mode**: update a specific section of an existing DESIGN.md
 - No arguments → **Interactive mode** (Step 3c): collaborative design conversation
 
-If `--audit` is set and no DESIGN.md exists, report: "No DESIGN.md found. Run `/ck:design` to create one." and stop.
+If `--audit` is set and no DESIGN.md exists, report: "No DESIGN.md found. Run `$ck-design` to create one." and stop.
 
-If `--section` is set and no DESIGN.md exists, report: "No DESIGN.md found. Run `/ck:design` to create the full design system first." and stop.
+If `--section` is set and no DESIGN.md exists, report: "No DESIGN.md found. Run `$ck-design` to create the full design system first." and stop.
 
 ## Step 3a: Import from Collection
 
@@ -229,7 +229,7 @@ Wait for response. If changes requested, make them and re-run Step 5.
    ## Conventions
    - DESIGN.md at project root is the canonical source
    - All UI implementation must reference DESIGN.md tokens and patterns
-   - Updated via /ck:design or automatically during /ck:check and /ck:revise
+   - Updated via $ck-design or automatically during $ck-check and $ck-revise
    - Agents read this before implementing any user-facing component
    ```
 
@@ -241,7 +241,7 @@ Wait for response. If changes requested, make them and re-run Step 5.
 
    | Date | Section | Change | Source |
    |------|---------|--------|--------|
-   | {today} | All | Initial design system created | /ck:design |
+   | {today} | All | Initial design system created | $ck-design |
    ```
 
 4. **Report:**
@@ -256,9 +256,9 @@ Wait for response. If changes requested, make them and re-run Step 5.
    **Responsive Breakpoints:** {count}
 
    ### Next Steps
-   - Run `/ck:sketch` to create kits — they'll reference this design system
-   - Run `/ck:design --audit` anytime to check design system health
-   - Run `/ck:design --section N` to update a specific section
+   - Run `$ck-sketch` to create kits — they'll reference this design system
+   - Run `$ck-design --audit` anytime to check design system health
+   - Run `$ck-design --section N` to update a specific section
    ```
 
 ---

--- a/commands/help.md
+++ b/commands/help.md
@@ -3,29 +3,29 @@ name: ck-help
 description: Show Cavekit commands and usage
 ---
 
-> **Note:** `/bp:help` is deprecated and will be removed in a future version. Use `/ck:help` instead.
+> **Note:** `$bp-help` is deprecated and will be removed in a future version. Use `$ck-help` instead.
 
 # Cavekit
 
 ## The Workflow
 
 ```
-/ck:init        →  bootstrap context hierarchy (optional, /ck:sketch does this too)
-/ck:design      →  create or update DESIGN.md (the LOOK) — import, extract, or design interactively
-/ck:research    →  deep multi-agent research (standalone, or integrated into /ck:sketch)
-/ck:sketch       →  write kits (the WHAT) — offers research if warranted, references DESIGN.md
-/ck:map   →  generate site (the ORDER) — includes design refs for UI tasks
-/ck:make       →  ralph loop (the BUILD) — task builders read DESIGN.md for UI work
-/ck:check     →  gap analysis + peer review + design compliance (the CHECK)
-/ck:config      →  show or change execution model presets
+$ck-init        →  bootstrap context hierarchy (optional, $ck-sketch does this too)
+$ck-design      →  create or update DESIGN.md (the LOOK) — import, extract, or design interactively
+$ck-research    →  deep multi-agent research (standalone, or integrated into $ck-sketch)
+$ck-sketch       →  write kits (the WHAT) — offers research if warranted, references DESIGN.md
+$ck-map   →  generate site (the ORDER) — includes design refs for UI tasks
+$ck-make       →  ralph loop (the BUILD) — task builders read DESIGN.md for UI work
+$ck-check     →  gap analysis + peer review + design compliance (the CHECK)
+$ck-config      →  show or change execution model presets
 ```
 
 ### Quick Mode
 
 ```bash
-/ck:quick <describe your feature>   # runs all 4 phases end-to-end, no stops
-/ck:quick add JWT auth --skip-inspect
-/ck:quick refactor the API layer --peer-review
+$ck-quick <describe your feature>   # runs all 4 phases end-to-end, no stops
+$ck-quick add JWT auth --skip-inspect
+$ck-quick refactor the API layer --peer-review
 ```
 
 Streamlined draft + architect (no interactive Q&A, no user gates) followed by the full build and inspect. Best for small-to-medium features where you trust the decomposition.
@@ -33,10 +33,10 @@ Streamlined draft + architect (no interactive Q&A, no user gates) followed by th
 ### Model Presets
 
 ```bash
-/ck:config                         # show effective preset + resolved models
-/ck:config list                    # show built-in presets
-/ck:config preset balanced         # set repo override
-/ck:config preset fast --global    # set your default for all repos
+$ck-config                         # show effective preset + resolved models
+$ck-config list                    # show built-in presets
+$ck-config preset balanced         # set repo override
+$ck-config preset fast --global    # set your default for all repos
 ```
 
 Built-in presets:
@@ -52,80 +52,80 @@ Precedence: `.cavekit/config` overrides `~/.cavekit/config`, which overrides the
 
 ## Commands
 
-### `/ck:init` — Bootstrap Context Hierarchy
+### `$ck-init` — Bootstrap Context Hierarchy
 
 ```bash
-/ck:init                         # create all context dirs, CLAUDE.md files, index files
+$ck-init                         # create all context dirs, agent instruction files, index files
 ```
 
 Creates the full context hierarchy for a Cavekit project. Idempotent — only creates what's missing. Detects legacy `context/sites/` layout and offers migration to `context/plans/`.
 
-### `/ck:research` — Deep Research
+### `$ck-research` — Deep Research
 
 ```bash
-/ck:research "build a Verse compiler targeting WASM"           # standard depth
-/ck:research "add real-time collab" --depth deep               # exhaustive
-/ck:research "refactor auth layer" --depth quick               # fast scan
-/ck:research "new React dashboard" --web-only                  # greenfield, skip codebase
-/ck:research "optimize DB queries" --codebase-only             # air-gapped, skip web
+$ck-research "build a Verse compiler targeting WASM"           # standard depth
+$ck-research "add real-time collab" --depth deep               # exhaustive
+$ck-research "refactor auth layer" --depth quick               # fast scan
+$ck-research "new React dashboard" --web-only                  # greenfield, skip codebase
+$ck-research "optimize DB queries" --codebase-only             # air-gapped, skip web
 ```
 
 Runs parallel multi-agent research (codebase exploration + web search) and produces a research brief in `context/refs/research-brief-{topic}.md`. Dispatches 2-8 agents depending on project size and depth. Two-pass synthesis cross-validates findings and resolves contradictions.
 
-Also integrated into `/ck:sketch` — when the draft phase detects a project that would benefit from research, it offers to run the pipeline inline before design Q&A.
+Also integrated into `$ck-sketch` — when the draft phase detects a project that would benefit from research, it offers to run the pipeline inline before design Q&A.
 
-### `/ck:design` — Create or Update DESIGN.md
+### `$ck-design` — Create or Update DESIGN.md
 
 ```bash
-/ck:design                        # interactive — collaborative design system creation
-/ck:design --import claude        # import from awesome-design-md collection
-/ck:design --import vercel        # import Vercel's design system as starting point
-/ck:design --from-site https://...  # extract design system from a live site
-/ck:design --audit                # quality check existing DESIGN.md
-/ck:design --section 2            # update just Section 2 (Color Palette)
+$ck-design                        # interactive — collaborative design system creation
+$ck-design --import claude        # import from awesome-design-md collection
+$ck-design --import vercel        # import Vercel's design system as starting point
+$ck-design --from-site https://...  # extract design system from a live site
+$ck-design --audit                # quality check existing DESIGN.md
+$ck-design --section 2            # update just Section 2 (Color Palette)
 ```
 
 Creates the project's visual design system document following the 9-section Google Stitch format. DESIGN.md becomes the authoritative visual reference that all agents consult when building UI.
 
-### `/ck:sketch` — Write Kits
+### `$ck-sketch` — Write Kits
 
 ```bash
-/ck:sketch                        # interactive — asks what to build
-/ck:sketch context/refs/          # from reference materials (PRDs, docs)
-/ck:sketch --from-code            # from existing codebase (brownfield)
-/ck:sketch --filter v2            # only generate v2 kits
+$ck-sketch                        # interactive — asks what to build
+$ck-sketch context/refs/          # from reference materials (PRDs, docs)
+$ck-sketch --from-code            # from existing codebase (brownfield)
+$ck-sketch --filter v2            # only generate v2 kits
 ```
 
 Decomposes your project into domains, writes `context/kits/cavekit-{domain}.md` files with R-numbered requirements and testable acceptance criteria.
 
-### `/ck:map` — Generate Site
+### `$ck-map` — Generate Site
 
 ```bash
-/ck:map                    # generates site from all kits
-/ck:map --filter v2        # only v2 kits
+$ck-map                    # generates site from all kits
+$ck-map --filter v2        # only v2 kits
 ```
 
 Reads kits, decomposes requirements into tasks, organizes into dependency tiers. Writes `context/plans/build-site.md`. No domain plans — just tasks and dependencies.
 
-### `/ck:make` — Run the Loop
+### `$ck-make` — Run the Loop
 
 ```bash
-/ck:make                       # auto-parallel build from site
-/ck:make --filter v2           # scope to v2
-/ck:make --peer-review         # add Codex (GPT-5.4) review
-/ck:make --max-iterations 30   # iteration limit
-/ck:make --peer-review --codex-model gpt-5.4-mini
+$ck-make                       # auto-parallel build from site
+$ck-make --filter v2           # scope to v2
+$ck-make --peer-review         # add Codex (GPT-5.4) review
+$ck-make --max-iterations 30   # iteration limit
+$ck-make --peer-review --codex-model gpt-5.4-mini
 ```
 
 Auto-archives any previous cycle, then builds the site. Automatically parallelizes by grouping ready tasks into a few coherent work packets based on shared files, subsystem, and complexity. Progresses through tiers autonomously without manual intervention. If multiple build sites exist, asks which one to implement.
 
 With `--peer-review`: alternates build and review iterations, calling Codex via MCP.
 
-### `/ck:check` — Post-Loop Inspection
+### `$ck-check` — Post-Loop Inspection
 
 ```bash
-/ck:check                     # inspect everything from last loop
-/ck:check --filter v2         # only v2
+$ck-check                     # inspect everything from last loop
+$ck-check --filter v2         # only v2
 ```
 
 Runs after build completes. Does two things:
@@ -134,32 +134,32 @@ Runs after build completes. Does two things:
 
 Produces a verdict: APPROVE / REVISE / REJECT with prioritized findings.
 
-### `/ck:config` — Execution Presets
+### `$ck-config` — Execution Presets
 
 ```bash
-/ck:config
-/ck:config list
-/ck:config preset quality
-/ck:config preset fast --global
+$ck-config
+$ck-config list
+$ck-config preset quality
+$ck-config preset fast --global
 ```
 
 Shows or updates the active Cavekit execution preset. Presets map three task buckets:
 `reasoning` for draft/architect/inspect-style work, `execution` for build/task-builder work, and `exploration` for research and codebase scanning helpers.
 
-### `/ck:progress` — Check Progress
+### `$ck-progress` — Check Progress
 
 ```bash
-/ck:progress                    # show site progress
-/ck:progress --filter v2
+$ck-progress                    # show site progress
+$ck-progress --filter v2
 ```
 
 Shows tasks done/ready/blocked, progress bar, current tier, and next tasks.
 
-### `/ck:judge` — On-Demand Codex Review
+### `$ck-judge` — On-Demand Codex Review
 
 ```bash
-/ck:judge                  # review current tier diff
-/ck:judge --base v1.0     # review diff against a specific ref
+$ck-judge                  # review current tier diff
+$ck-judge --base v1.0     # review diff against a specific ref
 ```
 
 Sends the current diff to Codex for adversarial review. Outputs findings in Cavekit format and appends them to `context/impl/impl-review-findings.md`. Requires Codex CLI to be installed.
@@ -168,12 +168,12 @@ Sends the current diff to Codex for adversarial review. Outputs findings in Cave
 
 | Command | When |
 |---------|------|
-| `/ck:judge` | On-demand Codex adversarial review of current diff |
-| `/ck:scan` | After a loop — compare built vs intended |
-| `/ck:revise` | After manual code fixes — trace back to kits |
-| `/ck:compact-specs` | When impl tracking files exceed ~500 lines |
-| `/ck:archive-loop` | Manually archive a loop cycle (build does this automatically) |
-| `/ck:next-session` | Generate a handoff document for next session |
+| `$ck-judge` | On-demand Codex adversarial review of current diff |
+| `$ck-scan` | After a loop — compare built vs intended |
+| `$ck-revise` | After manual code fixes — trace back to kits |
+| `$ck-compact-specs` | When impl tracking files exceed ~500 lines |
+| `$ck-archive-loop` | Manually archive a loop cycle (build does this automatically) |
+| `$ck-next-session` | Generate a handoff document for next session |
 
 ### Legacy (advanced)
 
@@ -181,14 +181,14 @@ These still work but are superseded by the three main commands:
 
 | Command | Replaced by |
 |---------|-------------|
-| `/cavekit init` | `/ck:init` (or `/ck:sketch` creates directories automatically) |
-| `/cavekit spec-from-refs` | `/ck:sketch context/refs/` |
-| `/cavekit spec-from-code` | `/ck:sketch --from-code` |
-| `/cavekit plan-from-specs` | `/ck:map` (generates site directly, no domain plans) |
-| `/cavekit implement` | `/ck:make` (one task at a time vs full loop) |
-| `/cavekit spec-loop` | `/ck:make` |
-| `/cavekit peer-review-loop` | `/ck:make --peer-review` |
-| `/cavekit quick` | `/ck:quick` (end-to-end with no stops) |
+| `/cavekit init` | `$ck-init` (or `$ck-sketch` creates directories automatically) |
+| `/cavekit spec-from-refs` | `$ck-sketch context/refs/` |
+| `/cavekit spec-from-code` | `$ck-sketch --from-code` |
+| `/cavekit plan-from-specs` | `$ck-map` (generates site directly, no domain plans) |
+| `/cavekit implement` | `$ck-make` (one task at a time vs full loop) |
+| `/cavekit spec-loop` | `$ck-make` |
+| `/cavekit peer-review-loop` | `$ck-make --peer-review` |
+| `/cavekit quick` | `$ck-quick` (end-to-end with no stops) |
 
 ## Skills (reference docs)
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -3,7 +3,7 @@ name: ck-init
 description: "Bootstrap the context hierarchy — creates all directories, CLAUDE.md files, and index files"
 ---
 
-> **Note:** `/bp:init` is deprecated and will be removed in a future version. Use `/ck:init` instead.
+> **Note:** `$bp-init` is deprecated and will be removed in a future version. Use `$ck-init` instead.
 
 # Cavekit Init — Bootstrap Context Hierarchy
 
@@ -13,7 +13,7 @@ Creates the full context hierarchy for a Cavekit project. Run once at the start 
 
 - **Idempotent** — creates only what's missing. Safe to re-run.
 - **Non-destructive** — never overwrites existing files.
-- **No questions** — does not ask what you're building (that's `/ck:sketch`).
+- **No questions** — does not ask what you're building (that's `$ck-sketch`).
 
 ## Step 1: Scan Existing Project Structure
 
@@ -129,7 +129,7 @@ The project's visual design system in DESIGN.md format (9-section Google Stitch)
 ## Conventions
 - DESIGN.md at project root is the canonical source
 - All UI implementation must reference DESIGN.md tokens and patterns
-- Updated via /ck:design or automatically during /ck:check and /ck:revise
+- Updated via $ck-design or automatically during $ck-check and $ck-revise
 - Agents read this before implementing any user-facing component
 - design-changelog.md tracks all design system changes
 ```
@@ -187,7 +187,7 @@ last_edited: "{CURRENT_DATE_UTC}"
 |----------|---------------|-----------------|
 
 ## Dependency Graph
-No domains defined yet. Run `/ck:sketch` to create kits.
+No domains defined yet. Run `$ck-sketch` to create kits.
 ```
 
 ### `context/plans/plan-overview.md`
@@ -204,7 +204,7 @@ last_edited: "{CURRENT_DATE_UTC}"
 | Site | File | Tasks | Done | Status |
 |------|------|-------|------|--------|
 
-No build sites yet. Run `/ck:map` to generate one.
+No build sites yet. Run `$ck-map` to generate one.
 ```
 
 ### `context/impl/impl-overview.md`
@@ -221,7 +221,7 @@ last_edited: "{CURRENT_DATE_UTC}"
 | Domain | Tasks Done | Tasks Total | Status |
 |--------|-----------|-------------|--------|
 
-No implementations tracked yet. Run `/ck:make` to start building.
+No implementations tracked yet. Run `$ck-make` to start building.
 ```
 
 ## Step 5: Detect Legacy Layout
@@ -264,7 +264,7 @@ Report what was created:
 - {migration status if applicable}
 
 ### Next Step
-Run `/ck:sketch` to start writing kits.
+Run `$ck-sketch` to start writing kits.
 ```
 
 Then commit the scaffolding with message: "Initialize Cavekit context hierarchy"

--- a/commands/judge.md
+++ b/commands/judge.md
@@ -5,9 +5,9 @@ argument-hint: "[--base REF]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/codex-review.sh:*)"]
 ---
 
-> **Note:** `/bp:codex-review`, `/ck:codex-review`, `/bp:judge` are deprecated aliases. Use `/ck:judge` instead.
+> **Note:** `$bp-codex-review`, `$ck-codex-review`, `$bp-judge` are deprecated aliases. Use `$ck-judge` instead.
 
-# /ck:judge — Codex Adversarial Review
+# $ck-judge — Codex Adversarial Review
 
 Run an on-demand adversarial code review using the Codex CLI. This sends the current diff to Codex for analysis of bugs, security issues, logic errors, and spec violations.
 

--- a/commands/make.md
+++ b/commands/make.md
@@ -5,7 +5,7 @@ argument-hint: "[FILE] [--filter PATTERN] [--peer-review] [--max-iterations N] [
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)", "Bash(git *)"]
 ---
 
-> **Note:** `/bp:build`, `/ck:build`, `/bp:make` are deprecated aliases. Use `/ck:make` instead.
+> **Note:** `$bp-build`, `$ck-build`, `$bp-make` are deprecated aliases. Use `$ck-make` instead.
 
 # Cavekit Build — Autonomous Implementation
 
@@ -38,7 +38,7 @@ Before entering the execution loop, validate that the build site covers all cave
      - cavekit-{domain}.md R{n}: {criterion text}
      - cavekit-{domain}.md R{n}: {criterion text}
    
-   Run `/ck:map` to regenerate the build site with full coverage, or continue with known gaps.
+   Run `$ck-map` to regenerate the build site with full coverage, or continue with known gaps.
    ```
    Ask the user whether to proceed or stop. Do NOT silently continue with gaps.
 5. If no gaps are found, log: `✓ Pre-flight coverage check passed — all criteria mapped to tasks.`
@@ -127,7 +127,7 @@ Once the setup script completes (outputs the ralph prompt), you run the executio
      1. `git merge <branch> --no-edit` — merge the subagent's branch
      2. `git worktree remove <worktree-path>` — remove the worktree directory (required before branch can be deleted)
      3. `git branch -D <branch>` — delete the branch
-     Skip all three steps if the subagent reported no changes (Claude Code auto-cleans worktrees with no changes). If a merge conflicts, clean up the worktree (`git worktree remove <worktree-path> --force`) before reporting the conflict.
+     Skip all three steps if the subagent reported no changes (the agent runner auto-cleans worktrees with no changes). If a merge conflicts, clean up the worktree (`git worktree remove <worktree-path> --force`) before reporting the conflict.
    - Update `context/impl/impl-*.md` with status for each completed task
    - Record any dead ends in `context/impl/dead-ends.md`
    - Update `context/impl/loop-log.md` with an iteration entry. **If `CAVEMAN_ACTIVE` is true**, compress the loop-log entry to a dense one-liner per task using caveman-speak. Instead of verbose iteration summaries, write compact entries like:
@@ -202,7 +202,7 @@ Before updating CLAUDE.md, verify that the build actually satisfies the kits:
 4. If gaps are found (criteria not covered by completed tasks):
    - Log each gap with its cavekit reference
    - Add the gaps as new tasks to the build site (append to the highest tier + 1)
-   - Report: `{n} gap(s) found — {n} remediation tasks added to build site. Run /ck:make again to address.`
+   - Report: `{n} gap(s) found — {n} remediation tasks added to build site. Run $ck-make again to address.`
 5. If no gaps: proceed to CLAUDE.md hierarchy update
 
 ### Post-Build: Update CLAUDE.md Hierarchy

--- a/commands/map.md
+++ b/commands/map.md
@@ -4,7 +4,7 @@ description: "Generate a build site from kits — the task dependency graph that
 argument-hint: "[--filter PATTERN]"
 ---
 
-> **Note:** `/bp:architect`, `/ck:architect`, `/bp:map` are deprecated aliases. Use `/ck:map` instead.
+> **Note:** `$bp-architect`, `$ck-architect`, `$bp-map` are deprecated aliases. Use `$ck-map` instead.
 
 # Cavekit Architect — Generate Build Site
 
@@ -25,7 +25,7 @@ Do NOT rely on the agent frontmatter model. Dispatch the actual site-generation 
 ## Step 1: Validate Kits Exist
 
 Check `context/kits/` for cavekit files. If none found, tell the user:
-> No kits found. Run `/ck:sketch` first.
+> No kits found. Run `$ck-sketch` first.
 
 If `--filter` is set, only include kits matching the filter pattern.
 
@@ -167,8 +167,8 @@ Rules for the graph:
 ### Tier 0 Tasks: {count} (can run in parallel immediately)
 
 ### Next Step
-Run `/ck:make` to start implementation (auto-parallelizes independent tasks).
-Run `/ck:make --peer-review` to add Codex review.
+Run `$ck-make` to start implementation (auto-parallelizes independent tasks).
+Run `$ck-make --peer-review` to add Codex review.
 ```
 
 ### Rules

--- a/commands/progress.md
+++ b/commands/progress.md
@@ -4,7 +4,7 @@ description: "Show progress against the build site or plan — tasks done, in pr
 argument-hint: "[--filter PATTERN]"
 ---
 
-> **Note:** `/bp:progress` is deprecated and will be removed in a future version. Use `/ck:progress` instead.
+> **Note:** `$bp-progress` is deprecated and will be removed in a future version. Use `$ck-progress` instead.
 
 # Cavekit Progress
 
@@ -14,7 +14,7 @@ Show the user a progress report by comparing the build site against implementati
 
 Look in `context/plans/` then `context/sites/` for `*site*`, `*plan*`, or `*frontier*` files (exclude `*overview*`). If `--filter` is set (parse from `$ARGUMENTS`), match against it.
 
-If no site/plan found: "No build site or plan found. Run `/ck:map` first."
+If no site/plan found: "No build site or plan found. Run `$ck-map` first."
 
 ## Step 2: Read State
 
@@ -74,7 +74,7 @@ For each task in the site:
 ### Loop Status
 - Iterations completed: {n}
 - Last iteration: {timestamp}
-- Active: {yes/no — .claude/ralph-loop.local.md exists?}
+- Active: {yes/no — loop state file exists?}
 ```
 
 Display this to the user.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -5,13 +5,13 @@ argument-hint: "<feature description> [--skip-inspect] [--peer-review] [--max-it
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)", "Bash(git *)"]
 ---
 
-> **Note:** `/bp:quick` is deprecated and will be removed in a future version. Use `/ck:quick` instead.
+> **Note:** `$bp-quick` is deprecated and will be removed in a future version. Use `$ck-quick` instead.
 
 # Cavekit Quick — End-to-End Feature Build
 
 Run the full Cavekit pipeline (draft → architect → build → inspect) from a single feature description with no stops for user input. Draft and architect phases are streamlined — no interactive design conversation, no user gates between phases.
 
-**When to use:** Small-to-medium features where you trust the agent's decomposition. For large or ambiguous projects, use `/ck:sketch` interactively instead.
+**When to use:** Small-to-medium features where you trust the agent's decomposition. For large or ambiguous projects, use `$ck-sketch` interactively instead.
 
 ## Phase 0: Resolve Execution Profile
 
@@ -33,9 +33,9 @@ Extract from `$ARGUMENTS`:
 - `--max-iterations N` — pass through to build phase
 
 If no feature description is provided:
-> Usage: `/ck:quick <describe what you want built>`
+> Usage: `$ck-quick <describe what you want built>`
 >
-> Example: `/ck:quick add a REST API for user profiles with CRUD operations and JWT auth`
+> Example: `$ck-quick add a REST API for user profiles with CRUD operations and JWT auth`
 
 Stop and wait for user input.
 
@@ -43,7 +43,7 @@ Stop and wait for user input.
 
 ## Phase 1: Quick Draft
 
-Streamlined version of `/ck:sketch` — no interactive Q&A, no approach proposals, no incremental presentation.
+Streamlined version of `$ck-sketch` — no interactive Q&A, no approach proposals, no incremental presentation.
 
 Do NOT run this phase inline in the parent thread. Dispatch a `ck:drafter` subagent with `model: "{REASONING_MODEL}"` and give it the quick-draft rules below. If that subagent needs helper exploration for repo scanning, it should dispatch those helpers with `model: "{EXPLORATION_MODEL}"`.
 
@@ -97,7 +97,7 @@ Proceed immediately — no user gate.
 
 ## Phase 2: Quick Architect
 
-Streamlined version of `/ck:map` — runs inline, no stopping.
+Streamlined version of `$ck-map` — runs inline, no stopping.
 
 Do NOT run this phase inline in the parent thread. Dispatch a `ck:map` subagent with `model: "{REASONING_MODEL}"` and give it the quick-architect rules below.
 
@@ -135,14 +135,14 @@ Proceed immediately — no user gate.
 
 ## Phase 3: Build
 
-Run the **full build phase** exactly as `/ck:make` defines it. This is NOT simplified — the build loop runs with all its rigor:
+Run the **full build phase** exactly as `$ck-make` defines it. This is NOT simplified — the build loop runs with all its rigor:
 
 1. Execute `"${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh"` with any passthrough flags (`--peer-review`, `--max-iterations`)
 2. Run the execution loop: compute frontier → dispatch tasks → merge → track → repeat
 3. Follow all circuit breakers (3 consecutive failures = BLOCKED, merge conflicts = stop)
 4. All critical rules apply: form coherent work packets, delegate only the packets that benefit from parallel execution, merge after every wave
 
-The build phase continues to use the explicit `EXECUTION_MODEL` resolved by `/ck:make`.
+The build phase continues to use the explicit `EXECUTION_MODEL` resolved by `$ck-make`.
 
 The build phase is where quality matters — no shortcuts here.
 
@@ -150,7 +150,7 @@ The build phase is where quality matters — no shortcuts here.
 
 ## Phase 4: Inspect (unless `--skip-inspect`)
 
-If `--skip-inspect` was NOT passed, run the **full inspect phase** exactly as `/ck:check` defines it:
+If `--skip-inspect` was NOT passed, run the **full inspect phase** exactly as `$ck-check` defines it:
 
 1. Dispatch a `ck:surveyor` subagent with `model: "{REASONING_MODEL}"` for the gap analysis
 2. Dispatch a `ck:inspector` subagent with `model: "{REASONING_MODEL}"` for the peer review
@@ -185,5 +185,5 @@ After all phases complete, present:
 ## {If inspect ran and verdict is REVISE or REJECT}
 ### Remaining Work
 {summary of gaps or findings}
-Run `/ck:make` to address remaining tasks, or `/ck:check` for details.
+Run `$ck-make` to address remaining tasks, or `$ck-check` for details.
 ```

--- a/commands/research.md
+++ b/commands/research.md
@@ -4,7 +4,7 @@ description: "Deep research for grounding kits in evidence — current best prac
 argument-hint: "<description> [--depth quick|standard|deep] [--web-only] [--codebase-only]"
 ---
 
-> **Note:** `/bp:research` is deprecated and will be removed in a future version. Use `/ck:research` instead.
+> **Note:** `$bp-research` is deprecated and will be removed in a future version. Use `$ck-research` instead.
 
 # Cavekit Research — Deep Multi-Agent Research
 

--- a/commands/revise.md
+++ b/commands/revise.md
@@ -3,7 +3,7 @@ name: ck-revise
 description: Trace recent manual code fixes back into kits and context files
 ---
 
-> **Note:** `/bp:revise` is deprecated and will be removed in a future version. Use `/ck:revise` instead.
+> **Note:** `$bp-revise` is deprecated and will be removed in a future version. Use `$ck-revise` instead.
 
 # Cavekit Revise — Trace Fixes to Kits
 
@@ -112,7 +112,7 @@ If the fix involves visual changes and `DESIGN.md` exists:
 - If the fix reveals an incorrect token value, update it
 - Log all changes to `context/designs/design-changelog.md`:
   ```markdown
-  | {date} | Section {N} | {what changed} | /ck:revise (commit {SHA}) |
+  | {date} | Section {N} | {what changed} | $ck-revise (commit {SHA}) |
   ```
 - Update the `last_edited` frontmatter date in DESIGN.md
 

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -3,7 +3,7 @@ name: ck-scan
 description: Compare what was built against what was intended
 ---
 
-> **Note:** `/bp:gap-analysis`, `/ck:gap-analysis`, `/bp:scan` are deprecated aliases. Use `/ck:scan` instead.
+> **Note:** `$bp-gap-analysis`, `$ck-gap-analysis`, `$bp-scan` are deprecated aliases. Use `$ck-scan` instead.
 
 # Cavekit Gap Analysis — Built vs. Intended
 
@@ -109,7 +109,7 @@ For each gap (PARTIAL, MISSING, OVER-BUILT, UNTESTABLE), determine the root caus
 | P1 | plan-{domain}.md | {what to update} | R{n} |
 
 ### Recommended Next Steps
-1. Run `/ck:revise` to trace gaps into context files
+1. Run `$ck-revise` to trace gaps into context files
 2. {Specific cavekit updates needed}
 3. {Specific plan updates needed}
 4. {Implementation work remaining}

--- a/commands/sketch.md
+++ b/commands/sketch.md
@@ -4,7 +4,7 @@ description: "Write kits: decompose what you're building into domains with testa
 argument-hint: "[REFS_PATH | --from-code] [--filter PATTERN]"
 ---
 
-> **Note:** `/bp:draft`, `/ck:draft`, `/bp:sketch` are deprecated aliases. Use `/ck:sketch` instead.
+> **Note:** `$bp-draft`, `$ck-draft`, `$bp-sketch` are deprecated aliases. Use `$ck-sketch` instead.
 
 # Cavekit Draft — Write Kits
 
@@ -478,10 +478,10 @@ Wait for the user's response. If they request changes, make them and re-run Step
 - {anything that couldn't be fully specified}
 
 ### Next Step
-Run `/ck:map` to generate the build site from these kits.
+Run `$ck-map` to generate the build site from these kits.
 ```
 
-Present the report. When the user is ready, transition to `/ck:map`.
+Present the report. When the user is ready, transition to `$ck-map`.
 
 ---
 

--- a/context/impl/impl-build-lifecycle.md
+++ b/context/impl/impl-build-lifecycle.md
@@ -13,6 +13,6 @@ last_edited: "2026-03-20T00:00:00Z"
 | T-011 | DONE | Recovery detection on build start (surfaces branch, last commit, diff stats). Resume proceeds through merge+env. --abandon flag for cleanup. |
 | T-012 | DONE | --abandon flag removes worktree (force), prunes, deletes branch |
 | T-013 | DONE | Resume flow cleans stale ralph-loop state then proceeds through normal merge (R1) + env verify (R2) path |
-| T-016 | DONE | Health check in setup-build.sh: detached HEAD (error), missing worktree (error), uncommitted changes (warning), missing env files (warning). Results written to .claude/health-check.json |
+| T-016 | DONE | Health check in setup-build.sh: detached HEAD (error), missing worktree (error), uncommitted changes (warning), missing env files (warning). Results written to the Cavekit health-check file |
 | T-017 | DONE | Health status/errors/warnings fields added to Instance struct; TUI instance list shows ⊘ (error) or △ (warning) indicator |
 | T-018 | DONE | archiveImplState() in lifecycle.go copies loop-log and impl-* files to archive/ on kill. Skips if zero tasks completed |

--- a/context/impl/impl-codex-bridge.md
+++ b/context/impl/impl-codex-bridge.md
@@ -7,7 +7,7 @@ last_edited: "2026-03-31T00:00:00Z"
 | Task | Status | Notes |
 |------|--------|-------|
 | T-001 | DONE | Codex binary detection via `codex --version`. scripts/codex-detect.sh |
-| T-002 | DONE | Plugin presence check across standard Claude Code plugin locations. scripts/codex-detect.sh |
+| T-002 | DONE | Local Codex integration check across legacy plugin locations and current Codex config paths. scripts/codex-detect.sh |
 | T-003 | DONE | Config schema: codex_review (auto/off), codex_model, codex_effort. scripts/codex-config.sh |
 | T-004 | DONE | Gate config: tier_gate_mode (severity/strict/permissive/off). scripts/codex-config.sh |
 | T-005 | DONE | codex_available flag and bp_codex_nudge already in codex-detect.sh |

--- a/context/impl/impl-codex-bridge.md
+++ b/context/impl/impl-codex-bridge.md
@@ -14,7 +14,7 @@ last_edited: "2026-03-31T00:00:00Z"
 | T-006 | DONE | Codex review invocation with finding parser. scripts/codex-review.sh |
 | T-007 | DONE | Finding format with source/tier columns. scripts/codex-findings.sh |
 | T-008 | DONE | Peer-review-loop replacement: Codex CLI primary, MCP legacy fallback. setup-build.sh + SKILL.md |
-| T-009 | DONE | /ck:judge standalone command. commands/codex-review.md |
+| T-009 | DONE | $ck-judge standalone command. commands/codex-review.md |
 | T-010 | DONE | Tier boundary hook in build loop. commands/build.md |
 | T-011 | DONE | Severity-based gating with fix-task generation. scripts/codex-gate.sh + build.md |
 | T-012 | DONE | Review-fix cycle with re-review and max iterations. bp_review_fix_cycle in codex-gate.sh |

--- a/context/impl/impl-command-gate.md
+++ b/context/impl/impl-command-gate.md
@@ -10,7 +10,7 @@ last_edited: "2026-03-31T00:00:00Z"
 | T-102 | DONE | Built-in allowlist (50+ safe executables, git subcommands) and blocklist (14 regex patterns) |
 | T-103 | DONE | Config schema: command_gate (all/interactive/off), model, timeout, user allowlist/blocklist |
 | T-104 | DONE | Fast-path classifier: bp_gate_fast_classify checks allowlist→blocklist→user lists→UNKNOWN |
-| T-105 | DONE | Claude permission integration: BP_HOOK_ALREADY_ALLOWED/BLOCKED env vars, skip gate if set |
+| T-105 | DONE | Runtime permission integration: BP_HOOK_ALREADY_ALLOWED/BLOCKED env vars, skip gate if set |
 | T-106 | DONE | Command normalizer: strips paths, quotes, subshells, hashes for cache keying |
 | T-107 | DONE | Codex safety classification: structured JSON prompt, parses safe/severity/reason |
 | T-108 | DONE | Pattern-based verdict cache: bash3-compatible temp file, keyed on normalized command |

--- a/context/kits/kit-build-lifecycle.md
+++ b/context/kits/kit-build-lifecycle.md
@@ -31,7 +31,7 @@ Robust worktree lifecycle management for the build system. Covers keeping worktr
 ### R3: Failure Recovery
 **Description:** When a build fails or is interrupted, the system offers structured recovery options instead of leaving an orphaned worktree.
 **Acceptance Criteria:**
-- [ ] On build failure or interruption, the user is presented with three options: (a) resume — rebase on main and restart the agent, (b) abandon — remove the worktree and its branch, (c) merge — merge whatever was completed back to main via the normal `/ck:merge` flow
+- [ ] On build failure or interruption, the user is presented with three options: (a) resume — rebase on main and restart the agent, (b) abandon — remove the worktree and its branch, (c) merge — merge whatever was completed back to main via the normal `$ck-merge` flow
 - [ ] The TUI surfaces worktree state for failed/interrupted instances (branch name, last commit, diff stats) so the user can make an informed choice
 - [ ] Abandoned worktrees are fully cleaned up (worktree removed, branch deleted if unmerged work is confirmed disposable)
 - [ ] Resume re-runs R1 (auto-rebase) and R2 (env var verification) before restarting the agent
@@ -63,7 +63,7 @@ Robust worktree lifecycle management for the build system. Covers keeping worktr
 - Worktree creation for non-build purposes
 
 ## Cross-References
-- See also: cavekit-spec-sync.md (worktree changes must be on main before `/ck:revise` can scan them)
+- See also: cavekit-spec-sync.md (worktree changes must be on main before `$ck-revise` can scan them)
 - See also: cavekit-worktree.md (existing worktree creation and discovery primitives this domain builds on)
 - See also: cavekit-session.md (instance lifecycle triggers build lifecycle operations)
 

--- a/context/kits/kit-cli.md
+++ b/context/kits/kit-cli.md
@@ -44,7 +44,7 @@ The command-line interface that replaces the current `cavekit` bash script. Prov
 - [ ] `cavekit kill` kills all `cavekit_*` tmux sessions
 - [ ] Removes all `{project}-cavekit-*` worktrees
 - [ ] Deletes all `cavekit/*` branches
-- [ ] Cleans up `.claude/ralph-loop.local.md` from project root and worktrees
+- [ ] Cleans up the Cavekit loop state file from project root and worktrees
 - [ ] Reports count of killed sessions, cleaned worktrees, deleted branches
 **Dependencies:** R1, cavekit-tmux R1, cavekit-worktree R1
 

--- a/context/kits/kit-cli.md
+++ b/context/kits/kit-cli.md
@@ -23,9 +23,9 @@ The command-line interface that replaces the current `cavekit` bash script. Prov
 **Description:** The primary command that launches the TUI.
 **Acceptance Criteria:**
 - [ ] `cavekit` or `cavekit monitor` launches the TUI
-- [ ] `--program <cmd>` overrides the default program (default: `claude`)
+- [ ] `--program <cmd>` overrides the default program (default: `codex`)
 - [ ] `--autoyes` / `-y` enables auto-approval of permission prompts
-- [ ] Preflight checks: tmux installed, program (claude) installed, git repo detected
+- [ ] Preflight checks: tmux installed, program (`codex` by default) installed, git repo detected
 - [ ] Loads persisted instances from previous session
 **Dependencies:** R1, cavekit-tui R1
 
@@ -60,7 +60,7 @@ The command-line interface that replaces the current `cavekit` bash script. Prov
 
 ## Out of Scope
 - Analytics command (keep as separate bash script for now)
-- Merge command (keep as Claude Code slash command)
+- Merge command (keep as a separate advanced workflow)
 - Plugin system
 
 ## Cross-References
@@ -69,5 +69,5 @@ The command-line interface that replaces the current `cavekit` bash script. Prov
 
 ## Changes
 - 2026-03-17: R2 acceptance criteria clarified — must parse --autoyes/-y flag and pass to TUI (finding F-010)
-- 2026-03-17: R2 acceptance criteria clarified — preflight must check program (claude) is installed (finding F-015)
+- 2026-03-17: R2 acceptance criteria clarified — preflight must check the selected program is installed (finding F-015)
 - 2026-03-17: R3 acceptance criteria clarified — must compute and display progress counts, not just worktree paths (finding F-012)

--- a/context/kits/kit-codex-bridge.md
+++ b/context/kits/kit-codex-bridge.md
@@ -34,7 +34,7 @@ When Codex is available, it becomes the sole adversary in Cavekit's peer-review-
 - [ ] Findings tagged with `source: codex` in `impl-review-findings.md`
 
 ### R4: Standalone Review Command
-A `/ck:judge` command that invokes Codex adversarial review on demand.
+A `$ck-judge` command that invokes Codex adversarial review on demand.
 - [ ] Default target: current build tier's diff against worktree base
 - [ ] Accept `--base <ref>` override for custom diff range
 - [ ] Output findings in Cavekit's standard finding format to stdout

--- a/context/kits/kit-codex-bridge.md
+++ b/context/kits/kit-codex-bridge.md
@@ -6,13 +6,13 @@ last_edited: "2026-03-31T00:00:00Z"
 # Cavekit: Codex Bridge
 
 ## Scope
-Everything related to detecting, configuring, and communicating with the Codex Claude Code plugin (`openai/codex-plugin-cc`) from within Cavekit. This domain makes Codex available as an adversary and provides a standalone review command.
+Everything related to detecting, configuring, and communicating with Codex from within Cavekit. This domain makes Codex available as an adversary and provides a standalone review command.
 
 ## Requirements
 
 ### R1: Plugin Detection
-Detect whether the Codex Claude Code plugin is installed and the `codex` binary is available.
-- [ ] Check for Codex plugin presence at Cavekit command entry (not a persistent daemon — a one-shot check)
+Detect whether local Codex integration is available and the `codex` binary is available.
+- [ ] Check for local Codex integration at Cavekit command entry (not a persistent daemon — a one-shot check)
 - [ ] Check `codex` binary is on PATH and responsive (`codex --version` or equivalent)
 - [ ] Expose a boolean `codex_available` flag consumable by other Cavekit components (e.g., as a shell function or variable in the build scripts)
 - [ ] When Codex is absent, emit a one-time suggestion to install it, then proceed with existing inspector-only review
@@ -42,9 +42,9 @@ A `$ck-judge` command that invokes Codex adversarial review on demand.
 - [ ] Error gracefully with a clear message if Codex is not installed
 
 ## Out of Scope
-- Codex plugin installation (that's `/codex:setup`'s job)
+- Codex installation itself
 - Build-loop orchestration and tier gating (that's Tier Gate's job)
-- Modifying the Codex plugin itself
+- Modifying Codex itself
 - MCP-based adversary as a fallback option (removed — Codex replaces it entirely when present)
 
 ## Cross-References

--- a/context/kits/kit-command-gate.md
+++ b/context/kits/kit-command-gate.md
@@ -6,15 +6,15 @@ last_edited: "2026-03-31T00:00:00Z"
 # Cavekit: Command Gate
 
 ## Scope
-A PreToolUse hook that intercepts Bash tool calls, classifies command safety using Codex (gpt-5.4-mini), and blocks unsafe commands before execution. Integrates with Claude Code's existing allow/block permission system and caches verdicts by normalized command pattern.
+A PreToolUse hook that intercepts Bash tool calls, classifies command safety using Codex (gpt-5.4-mini), and blocks unsafe commands before execution. Integrates with the active agent allow/block permission flow and caches verdicts by normalized command pattern.
 
 ## Requirements
 
 ### R1: PreToolUse Hook
-Intercept Bash tool calls before execution via Claude Code's PreToolUse hook system.
+Intercept Bash tool calls before execution via the active agent's PreToolUse hook system.
 - [ ] Register a PreToolUse hook that matches on Bash tool invocations
 - [ ] Extract the command string from the tool call parameters
-- [ ] Return one of: approve (allow execution), block (prevent execution with reason), or passthrough (defer to Claude's default permission system)
+- [ ] Return one of: approve (allow execution), block (prevent execution with reason), or passthrough (defer to the runtime's default permission system)
 - [ ] Hook timeout must be short enough to not noticeably delay interactive use (under 5 seconds)
 
 ### R2: Fast-Path Classification
@@ -31,15 +31,15 @@ Send ambiguous commands to Codex (gpt-5.4-mini) for safety classification.
 - [ ] Codex returns a structured verdict: safe (bool), reason (string), severity (info/warn/block)
 - [ ] `info` severity: approve silently
 - [ ] `warn` severity: approve but log the warning to stderr
-- [ ] `block` severity: block execution, return reason to Claude
+- [ ] `block` severity: block execution, return reason to the agent runtime
 - [ ] Model configurable via settings (default: gpt-5.4-mini)
 
-### R4: Claude Permission Integration
-Integrate with Claude Code's existing allow/block permission system rather than replacing it.
-- [ ] Commands already explicitly allowed in Claude's settings (e.g., `Bash(go test:*)`) bypass the gate entirely
-- [ ] Commands already explicitly blocked in Claude's settings are blocked before the gate runs
+### R4: Agent Permission Integration
+Integrate with the active agent's existing allow/block permission system rather than replacing it.
+- [ ] Commands already explicitly allowed in the runtime's settings (e.g., `Bash(go test:*)`) bypass the gate entirely
+- [ ] Commands already explicitly blocked in the runtime's settings are blocked before the gate runs
 - [ ] The gate only evaluates commands that would otherwise prompt the user for permission
-- [ ] Gate verdicts respect the same format Claude's permission system uses
+- [ ] Gate verdicts respect the same format the runtime's permission system uses
 
 ### R5: Pattern-Based Verdict Cache
 Cache Codex verdicts by normalized command pattern to avoid redundant API calls within a session.
@@ -65,7 +65,7 @@ User settings for the command gate.
 
 ## Out of Scope
 - Reviewing non-Bash tool calls (Edit, Write, etc.)
-- Modifying Claude Code's core permission system
+- Modifying the runtime's core permission system
 - Persistent cross-session learning from past verdicts
 - Reviewing commands after execution (post-hoc audit)
 

--- a/context/kits/kit-docs-page.md
+++ b/context/kits/kit-docs-page.md
@@ -46,7 +46,7 @@ A single-file (`docs.html`) documentation page with sticky sidebar navigation, d
 - [ ] Navigation tree with collapsible sections (chevron indicators):
   - Overview
   - Quick Start (children: Greenfield, Brownfield)
-  - Commands (children: all 10 `/ck:*` commands)
+  - Commands (children: all 10 `$ck-*` commands)
   - Methodology (children: Hunt Lifecycle, Kits as Source of Truth, Scientific Method Applied)
   - Codex Integration (children: Design Challenge, Tier Gate, Speculative Review, Command Safety Gate, Graceful Degradation)
   - Skills Reference (children: all 13 skills)
@@ -79,21 +79,21 @@ A single-file (`docs.html`) documentation page with sticky sidebar navigation, d
 **Acceptance Criteria:**
 - [ ] Two subsections: Greenfield and Brownfield
 - [ ] Each shows a full annotated conversation example (terminal-style code blocks)
-- [ ] Greenfield example: `/ck:sketch` → `/ck:map` → `/ck:make` with sample output
-- [ ] Brownfield example: `/ck:sketch --from-code` → `/ck:map --filter` → `/ck:make` with sample output
+- [ ] Greenfield example: `$ck-sketch` → `$ck-map` → `$ck-make` with sample output
+- [ ] Brownfield example: `$ck-sketch --from-code` → `$ck-map --filter` → `$ck-make` with sample output
 - [ ] Content derived from README "Quick Start" section
 
 ### R8: Commands Section
-**Description:** Reference for all Cavekit slash commands.
+**Description:** Reference for all Cavekit skills and CLI commands.
 **Acceptance Criteria:**
 - [ ] Each command gets its own subsection with:
-  - Command name in monospace heading (e.g., `/ck:sketch`)
+  - Command name in monospace heading (e.g., `$ck-sketch`)
   - Phase badge (Draft, Architect, Build, Inspect, or "Utility")
   - One-line description
   - Usage example in terminal code block
   - Flags/options table if applicable (e.g., `--from-code`, `--filter`)
   - Links to related commands
-- [ ] Commands covered: `/ck:sketch`, `/ck:map`, `/ck:make`, `/ck:check`, `/ck:research`, `/ck:progress`, `/ck:scan`, `/ck:revise`, `/ck:judge`, `/ck:help`
+- [ ] Commands covered: `$ck-sketch`, `$ck-map`, `$ck-make`, `$ck-check`, `$ck-research`, `$ck-progress`, `$ck-scan`, `$ck-revise`, `$ck-judge`, `$ck-help`
 - [ ] Content derived from README "Commands" section + individual command descriptions
 
 ### R9: Methodology Section

--- a/context/kits/kit-draft-challenge.md
+++ b/context/kits/kit-draft-challenge.md
@@ -6,7 +6,7 @@ last_edited: "2026-03-31T00:00:00Z"
 # Cavekit: Dual-Model Cavekit Drafting (Design Challenge)
 
 ## Scope
-After Claude drafts kits and the cavekit-reviewer passes them, send the kits to Codex for a "Design Challenge" review before presenting them to the user. Codex examines the domain decomposition, requirement coverage, and specification quality from a fundamentally different model perspective — catching blind spots Claude's own reviewer cannot.
+After the primary drafting flow produces kits and the cavekit-reviewer passes them, send the kits to Codex for a "Design Challenge" review before presenting them to the user. Codex examines the domain decomposition, requirement coverage, and specification quality from a fundamentally different model perspective — catching blind spots the primary drafting pass can miss.
 
 ## Requirements
 
@@ -25,14 +25,14 @@ Codex produces structured design feedback.
 - [ ] If Codex finds no critical issues, it returns an explicit approval
 
 ### R3: Auto-Fix and Re-Challenge Loop
-Claude addresses critical findings automatically.
-- [ ] Critical findings are addressed by Claude (edit kits, add missing requirements, clarify acceptance criteria)
+The primary drafting flow addresses critical findings automatically.
+- [ ] Critical findings are addressed by the drafting flow (edit kits, add missing requirements, clarify acceptance criteria)
 - [ ] After fixes, re-send to Codex for a second challenge pass
 - [ ] Maximum 2 challenge-fix cycles — after that, present remaining critical findings to the user for judgment
 - [ ] Advisory findings are collected and presented to the user alongside the kits (not auto-fixed)
 
 ### R4: Draft Flow Integration
-The design challenge integrates into the existing `/ck:sketch` command flow.
+The design challenge integrates into the existing `$ck-sketch` command flow.
 - [ ] Inserted between Step 8 (cavekit-reviewer loop) and Step 9 (user review gate)
 - [ ] When Codex is unavailable, skip the design challenge — the cavekit-reviewer loop alone is sufficient (graceful degradation)
 - [ ] The user review gate (Step 9) now shows both the kits AND any advisory findings from Codex, so the user has full context
@@ -46,10 +46,10 @@ The prompt sent to Codex is purpose-built for design-level review.
 - [ ] The prompt explicitly prohibits implementation-level feedback (no framework suggestions, no file path opinions)
 
 ## Out of Scope
-- Codex writing kits from scratch (Claude drafts, Codex challenges)
+- Codex writing kits from scratch (the primary drafting flow drafts, Codex challenges)
 - Codex reviewing implementation plans or build sites (that's the tier gate / inspector's job)
-- Multi-model consensus (only Claude + Codex, not additional models)
-- Challenging individual cavekit revisions (only the initial draft and `/ck:revise` outputs)
+- Multi-model consensus beyond the primary drafting flow + Codex
+- Challenging individual cavekit revisions (only the initial draft and `$ck-revise` outputs)
 
 ## Cross-References
 - See also: cavekit-codex-bridge.md (R1 for detection, R3 for invocation mechanism)

--- a/context/kits/kit-landing-page.md
+++ b/context/kits/kit-landing-page.md
@@ -7,7 +7,7 @@ last_edited: "2026-04-01T11:50:00Z"
 
 ## Scope
 
-A single-file (`index.html`) premium marketing landing page for the Cavekit Claude Code plugin, deployed to the `gh-pages` branch. Replaces the current site at `juliusbrussee.github.io/cavekit/`. Zero dependencies, zero build step. The page communicates what Cavekit does, why it matters, and how to install it through 8 scroll-driven sections with a "neon cavekit evolved" visual identity.
+A single-file (`index.html`) premium marketing landing page for the Codex-first Cavekit project, deployed to the `gh-pages` branch. Replaces the current site at `juliusbrussee.github.io/cavekit/`. Zero dependencies, zero build step. The page communicates what Cavekit does, why it matters, and how to install it through 8 scroll-driven sections with a "neon cavekit evolved" visual identity.
 
 ## Requirements
 
@@ -58,9 +58,9 @@ A single-file (`index.html`) premium marketing landing page for the Cavekit Clau
 **Acceptance Criteria:**
 - [ ] Section label: "ADVERSARIAL REVIEW"
 - [ ] Headline: "Two models. Different blind spots. Higher confidence."
-- [ ] Subheadline explaining Claude + Codex dual-model approach
+- [ ] Subheadline explaining the Codex-first build loop plus optional external review approach
 - [ ] Three full-width cards stacked vertically:
-  - Design Challenge (badge: PRE-BUILD): diagram showing Claude drafts → Reviewer approves → Codex challenges → User reviews
+  - Design Challenge (badge: PRE-BUILD): diagram showing primary drafting flow → Reviewer approves → Codex challenges → User reviews
   - Tier Gate (badge: BUILD-TIME): severity table with P0-P3 levels and colored indicators
   - Command Safety (badge: RUNTIME): flow diagram command → fast-path → Codex classifies → verdict
 - [ ] Each card has glassmorphism surface and a colored badge
@@ -101,7 +101,7 @@ A single-file (`index.html`) premium marketing landing page for the Cavekit Clau
 - [ ] Typewriter animation types both install commands at ~40ms/char with random jitter
 - [ ] Blinking cursor follows insertion point during typewriter
 - [ ] Copy button in terminal: "COPY" → "COPIED ✓" with green glow, `scale(0.97)` on `:active`
-- [ ] Requirements line: "Requires Claude Code, git, macOS/Linux."
+- [ ] Requirements line: "Requires Codex CLI, git, macOS/Linux."
 - [ ] Optional line: "Recommended: Codex for adversarial review, tmux for parallel agents."
 - [ ] Two CTA buttons: "View on GitHub →" (primary, blue glow) and "Read the Docs →" (secondary, links to docs.html)
 - [ ] `<noscript>` fallback shows full commands without typewriter

--- a/context/kits/kit-overview.md
+++ b/context/kits/kit-overview.md
@@ -6,7 +6,7 @@ last_edited: "2026-04-01T11:50:00Z"
 # Cavekit Overview
 
 ## Project
-Premium GitHub Pages website for the Cavekit Claude Code plugin. Two static HTML files deployed to the `gh-pages` branch: a marketing landing page and a single-page documentation reference. "Neon cavekit evolved" visual identity — dark backgrounds, glassmorphism surfaces, neon-blue accents, scroll-driven animations. Zero dependencies, zero build step.
+Premium GitHub Pages website for the Codex-first Cavekit project. Two static HTML files deployed to the `gh-pages` branch: a marketing landing page and a single-page documentation reference. "Neon cavekit evolved" visual identity — dark backgrounds, glassmorphism surfaces, neon-blue accents, scroll-driven animations. Zero dependencies, zero build step.
 
 ## Domain Index
 | Domain | Cavekit File | Requirements | Status | Description |

--- a/context/kits/kit-session.md
+++ b/context/kits/kit-session.md
@@ -24,7 +24,7 @@ The session (or "instance") model that ties together a tmux session, git worktre
 **Description:** Create, start, pause, resume, and kill instances.
 **Acceptance Criteria:**
 - [ ] Creating an instance: allocates title, sets site path, derives worktree name
-- [ ] Starting: creates worktree (if needed), creates tmux session, sends `/ck:make --filter {name}` after startup delay
+- [ ] Starting: creates worktree (if needed), creates tmux session, sends `$ck-make --filter {name}` after startup delay
 - [ ] Pausing: detaches tmux session from TUI tracking (session keeps running)
 - [ ] Resuming: re-attaches tmux session to TUI tracking
 - [ ] Killing: kills tmux session, optionally removes worktree and branch
@@ -40,7 +40,7 @@ The session (or "instance") model that ties together a tmux session, git worktre
 **Dependencies:** R1
 
 ### R4: Staggered Launch
-**Description:** When multiple instances are created at once, stagger their `/ck:make` commands to avoid resource contention.
+**Description:** When multiple instances are created at once, stagger their `$ck-make` commands to avoid resource contention.
 **Acceptance Criteria:**
 - [ ] Configurable delay between launches (default 5 seconds)
 - [ ] First instance starts immediately, subsequent ones wait

--- a/context/kits/kit-session.md
+++ b/context/kits/kit-session.md
@@ -11,12 +11,12 @@ The session (or "instance") model that ties together a tmux session, git worktre
 ## Requirements
 
 ### R1: Instance Model
-**Description:** A session instance represents one Claude Code agent working on one site.
+**Description:** A session instance represents one Codex agent working on one site.
 **Acceptance Criteria:**
 - [ ] Instance has: title, site path, worktree path, tmux session reference, status, program name, creation timestamp
 - [ ] Status enum: Loading, Running, Ready, Paused, Done
-- [ ] "Running" = Claude is actively generating output (pane content changing)
-- [ ] "Ready" = Claude is waiting for input (permission prompt or idle)
+- [ ] "Running" = the active agent is actively generating output (pane content changing)
+- [ ] "Ready" = the active agent is waiting for input (permission prompt or idle)
 - [ ] "Paused" = session checked out / detached from TUI management
 **Dependencies:** none
 
@@ -24,7 +24,7 @@ The session (or "instance") model that ties together a tmux session, git worktre
 **Description:** Create, start, pause, resume, and kill instances.
 **Acceptance Criteria:**
 - [ ] Creating an instance: allocates title, sets site path, derives worktree name
-- [ ] Starting: creates worktree (if needed), creates tmux session, sends `$ck-make --filter {name}` after startup delay
+- [ ] Starting: creates worktree (if needed), creates tmux session, sends the `$ck-make` build prompt for that site after startup delay
 - [ ] Pausing: detaches tmux session from TUI tracking (session keeps running)
 - [ ] Resuming: re-attaches tmux session to TUI tracking
 - [ ] Killing: kills tmux session, optionally removes worktree and branch
@@ -48,7 +48,7 @@ The session (or "instance") model that ties together a tmux session, git worktre
 **Dependencies:** R2
 
 ### R5: Auto-Yes Mode
-**Description:** Automatically approve Claude Code permission prompts.
+**Description:** Automatically approve runtime permission prompts.
 **Acceptance Criteria:**
 - [ ] When enabled, monitors pane content for permission prompts
 - [ ] Sends Enter keystroke to approve

--- a/context/kits/kit-site.md
+++ b/context/kits/kit-site.md
@@ -6,7 +6,7 @@ last_edited: "2026-03-19T00:00:00Z"
 # Spec: Site Discovery and Tracking
 
 ## Scope
-Finding site files, parsing their task structure, and tracking task completion from implementation files. This is the Cavekit-specific intelligence that claude-squad doesn't have.
+Finding site files, parsing their task structure, and tracking task completion from implementation files. This is the Cavekit-specific intelligence that the generic orchestration layer doesn't have.
 
 ## Requirements
 
@@ -45,7 +45,7 @@ Finding site files, parsing their task structure, and tracking task completion f
 - [ ] "done" — all tasks complete
 - [ ] "in-progress" — has an active worktree with Ralph Loop running
 - [ ] "available" — has incomplete tasks, no active worktree
-- [ ] Status detection checks for `.claude/ralph-loop.local.md` in the site's worktree
+- [ ] Status detection checks for the Cavekit loop state file in the site's worktree
 **Dependencies:** R3
 
 ### R5: Progress Summary
@@ -63,7 +63,7 @@ Finding site files, parsing their task structure, and tracking task completion f
 - [ ] Ranking priority: active worktree with Ralph Loop (score 3) > worktree exists or has incomplete tasks (score 2) > base (score 1)
 - [ ] Ties break deterministically: first candidate in alphabetical order wins (use `>` not `>=` in score comparison)
 - [ ] All task ID grep patterns use `$TASK_ID_PATTERN` variable, never hardcoded subsets
-- [ ] When listing candidates, mark the selected one with `→` for Claude visibility
+- [ ] When listing candidates, mark the selected one with `→` for clear agent visibility
 **Dependencies:** R1, R3
 
 ## Back-Propagated

--- a/context/kits/kit-site.md
+++ b/context/kits/kit-site.md
@@ -77,7 +77,7 @@ The following requirements were added after tracing manual bug fixes back to spe
 - **R6 (deterministic ties)**: Added to prevent non-deterministic ranking when multiple candidates score equally
 
 ## Out of Scope
-- Site creation (handled by `/ck:map`)
+- Site creation (handled by `$ck-map`)
 - Site modification/updating
 - Spec file parsing (site references specs but doesn't need their content)
 

--- a/context/kits/kit-spec-sync.md
+++ b/context/kits/kit-spec-sync.md
@@ -6,12 +6,12 @@ last_edited: "2026-03-20T00:00:00Z"
 # Cavekit: Spec Sync
 
 ## Scope
-Making kits the living source of truth for the repository. Kits always reflect the current state of the system. Changes flow bidirectionally — specs drive builds, and code changes flow back into specs via `/ck:revise`. Each cavekit maintains a changelog tracking its evolution over time.
+Making kits the living source of truth for the repository. Kits always reflect the current state of the system. Changes flow bidirectionally — specs drive builds, and code changes flow back into specs via `$ck-revise`. Each cavekit maintains a changelog tracking its evolution over time.
 
 ## Requirements
 
 ### R1: Spec-Aware Revision
-**Description:** `/ck:revise` scans recent git commits (since last revision) and identifies which cavekit requirements are affected by the changes. It updates those requirements to reflect the current implementation, replacing outdated descriptions and acceptance criteria with what actually exists now.
+**Description:** `$ck-revise` scans recent git commits (since last revision) and identifies which cavekit requirements are affected by the changes. It updates those requirements to reflect the current implementation, replacing outdated descriptions and acceptance criteria with what actually exists now.
 **Acceptance Criteria:**
 - [ ] Given commits that changed a module's behavior, running revise updates the relevant cavekit requirements to describe the new behavior
 - [ ] Requirements not affected by recent changes remain untouched
@@ -25,7 +25,7 @@ Making kits the living source of truth for the repository. Kits always reflect t
 - [ ] Changelog entries include: ISO date, affected requirement IDs, summary of change, and commit SHAs
 - [ ] Changelog is append-only — entries are never modified or removed
 - [ ] The requirements section contains only current-state descriptions (no versioning, no "was previously X")
-- [ ] New kits created via `/ck:sketch` start with an empty `## Changelog` section
+- [ ] New kits created via `$ck-sketch` start with an empty `## Changelog` section
 **Dependencies:** none
 
 ### R3: Cavekit Overview Consistency
@@ -50,7 +50,7 @@ Making kits the living source of truth for the repository. Kits always reflect t
 - Auto-triggering revise via hooks (it is always an explicit command)
 - Modifying the build site automatically (that is the architect's responsibility)
 - Tracking non-code changes (design files, external documentation)
-- Brownfield reverse-engineering (that is `/ck:sketch --from-code`, a separate flow)
+- Brownfield reverse-engineering (that is `$ck-sketch --from-code`, a separate flow)
 
 ## Cross-References
 - See also: cavekit-build-lifecycle.md (worktree changes must be merged to main before revise can scan them)

--- a/context/kits/kit-speculative-review.md
+++ b/context/kits/kit-speculative-review.md
@@ -6,7 +6,7 @@ last_edited: "2026-03-31T00:00:00Z"
 # Cavekit: Speculative Pre-Build Review
 
 ## Scope
-Run Codex adversarial review of the previous tier in the background while Claude builds the current tier. By the time the current tier finishes, the review of the previous tier is already complete, cutting tier gate latency to near-zero.
+Run Codex adversarial review of the previous tier in the background while the active build loop works on the current tier. By the time the current tier finishes, the review of the previous tier is already complete, cutting tier gate latency to near-zero.
 
 ## Requirements
 
@@ -46,7 +46,7 @@ Settings to control speculative review behavior.
 ## Out of Scope
 - Speculative building (starting Tier N+1 before Tier N's review is resolved) — too risky, findings could invalidate Tier N+1's work
 - Reviewing multiple tiers ahead — only one tier of overlap
-- Modifying the Codex plugin's background job mechanism
+- Modifying Codex's background job mechanism
 
 ## Cross-References
 - See also: cavekit-tier-gate.md (speculative review feeds into tier gate gating logic)

--- a/context/kits/kit-tier-gate.md
+++ b/context/kits/kit-tier-gate.md
@@ -11,7 +11,7 @@ The mechanism that invokes Codex adversarial review at the end of every build ti
 ## Requirements
 
 ### R1: Tier Boundary Hook
-Invoke Codex adversarial review automatically at the end of every completed tier during `/ck:make`.
+Invoke Codex adversarial review automatically at the end of every completed tier during `$ck-make`.
 - [ ] After all tasks in a tier are merged and impl tracking is updated, trigger a Codex review of the tier's cumulative diff
 - [ ] The diff target is: worktree base to current HEAD (captures everything built in this tier)
 - [ ] The review runs inline (not background) — the build loop waits for results before advancing

--- a/context/kits/kit-tmux.md
+++ b/context/kits/kit-tmux.md
@@ -51,7 +51,7 @@ Managing detached tmux sessions as the execution backend for Claude Code instanc
 **Description:** Send keystrokes and prompts to a detached tmux session.
 **Acceptance Criteria:**
 - [ ] Can send Enter keystroke
-- [ ] Can send arbitrary key sequences (for `/ck:make` command injection)
+- [ ] Can send arbitrary key sequences (for `$ck-make` command injection)
 - [ ] Can send multi-line prompt text
 **Dependencies:** R1
 

--- a/context/kits/kit-tmux.md
+++ b/context/kits/kit-tmux.md
@@ -6,12 +6,12 @@ last_edited: "2026-03-17T00:00:00Z"
 # Spec: Tmux Session Management
 
 ## Scope
-Managing detached tmux sessions as the execution backend for Claude Code instances. Each agent runs in its own isolated tmux session. The TUI never renders tmux panes directly — it captures snapshots for preview and attaches for full interaction.
+Managing detached tmux sessions as the execution backend for Cavekit agent sessions. Each agent runs in its own isolated tmux session. The TUI never renders tmux panes directly — it captures snapshots for preview and attaches for full interaction.
 
 ## Requirements
 
 ### R1: Session Lifecycle
-**Description:** Create, restore, and destroy detached tmux sessions running Claude Code (or other programs).
+**Description:** Create, restore, and destroy detached tmux sessions running Codex (or other programs).
 **Acceptance Criteria:**
 - [ ] Can create a new detached tmux session with a given name, working directory, and program
 - [ ] Session names are sanitized (no whitespace, dots replaced with underscores, prefixed with `sdd_`)
@@ -40,10 +40,10 @@ Managing detached tmux sessions as the execution backend for Claude Code instanc
 **Dependencies:** R1
 
 ### R4: Status Detection
-**Description:** Detect whether Claude Code is actively working or waiting for input.
+**Description:** Detect whether the active agent is working or waiting for input.
 **Acceptance Criteria:**
 - [ ] Detects "active" state by hashing pane content and comparing to previous hash
-- [ ] Detects "prompt" state by checking for Claude Code permission prompts ("No, and tell Claude what to do differently")
+- [ ] Detects "prompt" state by checking for permission prompts such as "No, and tell Codex what to do differently"
 - [ ] Detects trust prompts ("Do you trust the files in this folder?") and auto-dismisses them
 **Dependencies:** R2
 

--- a/context/kits/kit-tui.md
+++ b/context/kits/kit-tui.md
@@ -82,7 +82,7 @@ The bubbletea-based TUI that replaces the current tmux split-pane layout. Render
 - [ ] Press `n` to start: shows name input field at the bottom of the instance list
 - [ ] Press `N` (Shift+N) to start with prompt: shows name input, then prompt+branch picker overlay
 - [ ] Name input validates: non-empty, max 32 chars
-- [ ] On Enter: creates instance, starts worktree+tmux, sends `/ck:make --filter {name}`
+- [ ] On Enter: creates instance, starts worktree+tmux, sends `$ck-make --filter {name}`
 - [ ] Esc cancels and removes the pending instance
 **Dependencies:** R2, R7, cavekit-session R2
 

--- a/context/kits/kit-worktree.md
+++ b/context/kits/kit-worktree.md
@@ -33,7 +33,7 @@ Creating and managing git worktrees for isolated agent execution. Each agent get
 **Acceptance Criteria:**
 - [ ] Scans `{project_root}/../{project_name}-cavekit-*` directories
 - [ ] Returns worktree path, branch name, and derived site name for each
-- [ ] Detects if a worktree has an active Ralph Loop (`.claude/ralph-loop.local.md` exists)
+- [ ] Detects if a worktree has active Cavekit loop state (`.cavekit/loop-state.local.md` exists, with legacy fallback)
 **Dependencies:** R1
 
 ### R4: Branch Push

--- a/context/kits/kit-worktree.md
+++ b/context/kits/kit-worktree.md
@@ -46,7 +46,7 @@ Creating and managing git worktrees for isolated agent execution. Each agent get
 
 ## Out of Scope
 - Git authentication/credentials
-- Merge conflict resolution (handled by `/ck:merge`)
+- Merge conflict resolution (handled by `$ck-merge`)
 - Non-Cavekit worktree management
 
 ## Cross-References

--- a/context/plans/build-site-codex.md
+++ b/context/plans/build-site-codex.md
@@ -35,7 +35,7 @@ last_edited: "2026-03-31T00:00:00Z"
 | Task | Title | Cavekit | Requirement | blockedBy | Effort |
 |------|-------|-----------|-------------|-----------|--------|
 | T-008 | Peer-review-loop replacement (Codex replaces MCP adversary) | cavekit-codex-bridge.md | R3 | T-005, T-006 | M |
-| T-009 | `/ck:judge` standalone command | cavekit-codex-bridge.md | R4 | T-005, T-006 | M |
+| T-009 | `$ck-judge` standalone command | cavekit-codex-bridge.md | R4 | T-005, T-006 | M |
 | T-010 | Tier boundary hook in build loop | cavekit-tier-gate.md | R1 | T-006, T-007 | M |
 
 ---
@@ -115,4 +115,4 @@ graph LR
 | tier-gate | R4 (Finding Integration) | T-007 |
 
 ### Next Step
-Run `/ck:make` to start implementation (auto-parallelizes independent tasks).
+Run `$ck-make` to start implementation (auto-parallelizes independent tasks).

--- a/context/plans/build-site-coherence.md
+++ b/context/plans/build-site-coherence.md
@@ -14,7 +14,7 @@ last_edited: "2026-03-20T00:00:00Z"
 | Task | Title | Cavekit | Requirement | Effort |
 |------|-------|-----------|-------------|--------|
 | T-001 | Add changelog section to cavekit format | cavekit-spec-sync.md | R2 | S |
-| T-002 | Ensure /ck:sketch generates kits with empty changelog | cavekit-spec-sync.md | R2 | S |
+| T-002 | Ensure $ck-sketch generates kits with empty changelog | cavekit-spec-sync.md | R2 | S |
 | T-003 | Implement changelog append logic | cavekit-spec-sync.md | R2 | M |
 | T-004 | Merge main into existing worktree branch on build start | cavekit-build-lifecycle.md | R1 | M |
 | T-005 | Handle merge conflicts with user notification and options | cavekit-build-lifecycle.md | R1 | M |

--- a/context/plans/build-site-command-gate.md
+++ b/context/plans/build-site-command-gate.md
@@ -107,5 +107,5 @@ This site depends on `build-site-codex.md` tasks T-001 and T-002 (Codex binary d
 | command-gate | R7 (Configuration) | T-103, T-110 |
 
 ### Next Step
-Run `/ck:make` to start implementation.
+Run `$ck-make` to start implementation.
 If building alongside the Codex review integration, run both sites — Tier 0 tasks are independent.

--- a/context/plans/build-site-command-gate.md
+++ b/context/plans/build-site-command-gate.md
@@ -24,7 +24,7 @@ last_edited: "2026-03-31T00:00:00Z"
 | Task | Title | Cavekit | Requirement | blockedBy | Effort |
 |------|-------|-----------|-------------|-----------|--------|
 | T-104 | Fast-path classifier (allowlist/blocklist lookup in hook) | cavekit-command-gate.md | R2 | T-101, T-102 | M |
-| T-105 | Claude permission system integration (skip gate for pre-allowed/blocked) | cavekit-command-gate.md | R4 | T-101, T-103 | M |
+| T-105 | Runtime permission system integration (skip gate for pre-allowed/blocked) | cavekit-command-gate.md | R4 | T-101, T-103 | M |
 | T-106 | Command normalizer (strip variable args, preserve structure + flags) | cavekit-command-gate.md | R5 | T-102 | M |
 
 ---

--- a/context/plans/build-site-draft-challenge.md
+++ b/context/plans/build-site-draft-challenge.md
@@ -92,4 +92,4 @@ Requires from `build-site-codex.md`:
 | draft-challenge | R5 (Challenge Prompt Design) | T-301 |
 
 ### Next Step
-Run `/ck:make` after `build-site-codex` Tier 1 is complete.
+Run `$ck-make` after `build-site-codex` Tier 1 is complete.

--- a/context/plans/build-site-speculative-review.md
+++ b/context/plans/build-site-speculative-review.md
@@ -105,4 +105,4 @@ Requires from `build-site-codex.md`:
 | speculative-review | R5 (Configuration) | T-201 |
 
 ### Next Step
-Run `/ck:make` after `build-site-codex` Tier 1 is complete.
+Run `$ck-make` after `build-site-codex` Tier 1 is complete.

--- a/context/plans/build-site.md
+++ b/context/plans/build-site.md
@@ -50,7 +50,7 @@ last_edited: "2026-04-01T12:00:00Z"
 
 **T-003 details:** "THE PROBLEM" section. Headline: "AI coding agents are powerful. They fail in predictable ways." 2×2 card grid (1-col mobile). Cards: glassmorphism + red-tinted border, neon-red monospace title with glow, description, severity bar (fills 70-90% on scroll, `ease-out` 800ms). Stagger: 80ms between cards, `translateY(12px)` entrance.
 
-**T-004 details:** "HOW IT WORKS" section. 4 horizontal cards (vertical mobile): Draft, Architect, Build, Inspect. Large phase letter (48px, blue glow), name, `/ck:*` command pill, one-liner. Connected by animated glow lines with traveling pulse. Paragraph below about kits as source of truth. Stagger: 100ms between cards.
+**T-004 details:** "HOW IT WORKS" section. 4 horizontal cards (vertical mobile): Draft, Architect, Build, Inspect. Large phase letter (48px, blue glow), name, `$ck-*` command pill, one-liner. Connected by animated glow lines with traveling pulse. Paragraph below about kits as source of truth. Stagger: 100ms between cards.
 
 **T-005 details:** "ADVERSARIAL REVIEW" section. Headline + subheadline. 3 stacked full-width cards: Design Challenge (PRE-BUILD badge, Claude→Reviewer→Codex→User flow diagram), Tier Gate (BUILD-TIME badge, P0-P3 severity table with colored dots), Command Safety (RUNTIME badge, command→fast-path→classify→verdict flow). Glassmorphism cards with colored badges. Note about additive features. Stagger: 100ms. Mini diagrams draw after card visible (+300ms).
 
@@ -87,9 +87,9 @@ last_edited: "2026-04-01T12:00:00Z"
 | T-015 | Docs content: Codex Integration (5 subsections) | cavekit-docs-page.md | R10 | T-010, T-011 | M |
 | T-016 | Docs content: Skills Reference + Configuration | cavekit-docs-page.md | R11, R12 | T-010, T-011 | M |
 
-**T-012 details:** Overview section: what Cavekit is, who it's for, specification layer concept, brief Hunt summary with links to Commands/Methodology sections. Quick Start: Greenfield subsection (annotated `/ck:sketch` → `/ck:map` → `/ck:make` conversation) and Brownfield subsection (`--from-code` → `--filter` conversation). Content from README "The Idea", "How It Works" intro, and "Quick Start".
+**T-012 details:** Overview section: what Cavekit is, who it's for, specification layer concept, brief Hunt summary with links to Commands/Methodology sections. Quick Start: Greenfield subsection (annotated `$ck-sketch` → `$ck-map` → `$ck-make` conversation) and Brownfield subsection (`--from-code` → `--filter` conversation). Content from README "The Idea", "How It Works" intro, and "Quick Start".
 
-**T-013 details:** Commands section with 10 command entries. Each: monospace heading, phase badge (Draft/Architect/Build/Inspect/Utility), description, terminal usage example, flags/options table where applicable, related command links. Commands: `/ck:sketch` (flags: `--from-code`), `/ck:map` (flags: `--filter`), `/ck:make` (flags: `--peer-review`), `/ck:check`, `/ck:research`, `/ck:progress`, `/ck:scan`, `/ck:revise`, `/ck:judge`, `/ck:help`. Content from README "Commands" + CLI help.
+**T-013 details:** Commands section with 10 command entries. Each: monospace heading, phase badge (Draft/Architect/Build/Inspect/Utility), description, terminal usage example, flags/options table where applicable, related command links. Commands: `$ck-sketch` (flags: `--from-code`), `$ck-map` (flags: `--filter`), `$ck-make` (flags: `--peer-review`), `$ck-check`, `$ck-research`, `$ck-progress`, `$ck-scan`, `$ck-revise`, `$ck-judge`, `$ck-help`. Content from README "Commands" + CLI help.
 
 **T-014 details:** Methodology section. Hunt Lifecycle: detailed phase walkthrough with what each produces. Kits as Source of Truth: why specs drive development. Scientific Method Applied: hypothesis→test→observe→refine mapped to kits→gates→loops→revision. Content from README "Methodology" and "Why Cavekit".
 

--- a/example.md
+++ b/example.md
@@ -3,14 +3,14 @@
 ## Greenfield: Task management API
 
 ```
-user: /ck:sketch
+user: $ck-sketch
 
-claude: What are you building?
+codex: What are you building?
 
 user: A task management API. Users create projects, add tasks with priorities
       and due dates, assign tasks to team members. REST API, PostgreSQL.
 
-claude: Decomposing into domains...
+codex: Decomposing into domains...
 
       Created 4 kits:
       - cavekit-users.md (4 requirements, 12 acceptance criteria)
@@ -19,11 +19,11 @@ claude: Decomposing into domains...
       - cavekit-notifications.md (3 requirements, 8 acceptance criteria)
 
       Dependency order: users → projects → tasks → notifications
-      Next: /ck:map
+      Next: $ck-map
 
-user: /ck:map
+user: $ck-map
 
-claude: Reading 4 kits, 22 requirements...
+codex: Reading 4 kits, 22 requirements...
 
       Generated build site: 34 tasks, 5 tiers
       - Tier 0: DB schema, user model (3 tasks)
@@ -32,11 +32,11 @@ claude: Reading 4 kits, 22 requirements...
       - Tier 3: Task CRUD, assignments (10 tasks)
       - Tier 4: Notifications (8 tasks)
 
-      Next: /ck:make
+      Next: $ck-make
 
-user: /ck:make
+user: $ck-make
 
-claude: Loop activated! 34 tasks, 20 max iterations.
+codex: Loop activated! 34 tasks, 20 max iterations.
 
       --- Iteration 1 ---
       T-001: Database Schema Setup (Tier 0, cavekit-users.md R1)
@@ -57,9 +57,9 @@ claude: Loop activated! 34 tasks, 20 max iterations.
 ## Brownfield: Adding collaboration to existing Next.js app
 
 ```
-user: /ck:sketch --from-code
+user: $ck-sketch --from-code
 
-claude: Exploring codebase... Next.js 14, Prisma, NextAuth.
+codex: Exploring codebase... Next.js 14, Prisma, NextAuth.
 
       Found 6 domains. Created kits:
       - cavekit-auth.md (5 requirements — all satisfied by existing code)
@@ -72,18 +72,18 @@ claude: Exploring codebase... Next.js 14, Prisma, NextAuth.
       4 requirements are gaps (not yet implemented).
 
 user: I only want the collaboration features.
-      /ck:map --filter collaboration
+      $ck-map --filter collaboration
 
-claude: Reading cavekit-collaboration.md (3 requirements)...
+codex: Reading cavekit-collaboration.md (3 requirements)...
 
       Generated build site: 8 tasks, 3 tiers
       - Tier 0: WebSocket setup, presence types
       - Tier 1: Cursor presence, CRDT integration
       - Tier 2: Conflict resolution, live sync
 
-user: /ck:make --filter collaboration
+user: $ck-make --filter collaboration
 
-claude: Loop activated! 8 tasks.
+codex: Loop activated! 8 tasks.
 
       --- Iteration 1 ---
       T-001: WebSocket Server (Tier 0, R1)
@@ -93,10 +93,10 @@ claude: Loop activated! 8 tasks.
       All done. <promise>CAVEKIT COMPLETE</promise>
 
 user: Now notifications with peer review.
-      /ck:map --filter notifications
-      /ck:make --filter notifications --peer-review
+      $ck-map --filter notifications
+      $ck-make --filter notifications --peer-review
 
-claude: Archived previous cycle → context/impl/archive/20260314-201500/
+codex: Archived previous cycle → context/impl/archive/20260314-201500/
       Configured Codex (gpt-5.4) as peer reviewer.
 
       --- Iteration 1 (BUILD) ---
@@ -116,7 +116,7 @@ claude: Archived previous cycle → context/impl/archive/20260314-201500/
 ## The flow
 
 ```
-/ck:sketch      →  kits
-/ck:map  →  build site
-/ck:make      →  code
+$ck-sketch      →  kits
+$ck-map  →  build site
+$ck-make      →  code
 ```

--- a/install.sh
+++ b/install.sh
@@ -3,16 +3,12 @@
 # Cavekit Installer
 #
 # Usage:
-#   git clone https://github.com/JuliusBrussee/cavekit.git ~/.cavekit && ~/.cavekit/install.sh
+#   git clone https://github.com/astrawinski/cavekit.git ~/.cavekit && ~/.cavekit/install.sh
 
 set -euo pipefail
 
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLAUDE_DIR="$HOME/.claude"
-SETTINGS_FILE="$CLAUDE_DIR/settings.json"
 BIN_DIR="/usr/local/bin"
-MARKETPLACE_NAME="cavekit-local"
-MARKETPLACE_DIR="$CLAUDE_DIR/plugins/local/cavekit-marketplace"
 
 # ─── Colors ─────────────────────────────────────────────────────────────────
 
@@ -33,109 +29,12 @@ printf "${B}Installer${R}\n\n"
 # ─── Preflight ──────────────────────────────────────────────────────────────
 
 command -v git &>/dev/null || fail "git not found."
-command -v claude &>/dev/null || warn "claude CLI not found. Install Claude Code to use /ck:... commands."
-command -v codex &>/dev/null || warn "codex CLI not found. Codex local plugin sync will still be configured."
+command -v codex &>/dev/null || warn "codex CLI not found. Install Codex CLI to invoke Cavekit with \$ck-* skills."
 command -v tmux &>/dev/null || warn "tmux not found. Install for the parallel launcher: brew install tmux"
-
-# ─── Create marketplace with symlink to repo ─────────────────────────────
-
-info "Setting up Cavekit marketplace..."
-
-mkdir -p "$MARKETPLACE_DIR/.claude-plugin"
-
-# Symlink the repo as the "ck" plugin (primary) and "bp" (deprecated alias)
-ln -sfn "$INSTALL_DIR" "$MARKETPLACE_DIR/ck"
-ln -sfn "$INSTALL_DIR" "$MARKETPLACE_DIR/bp"
-
-# Write marketplace metadata
-cat > "$MARKETPLACE_DIR/.claude-plugin/marketplace.json" <<EOF
-{
-  "name": "$MARKETPLACE_NAME",
-  "owner": { "name": "$(whoami)" },
-  "metadata": {
-    "description": "Local Cavekit plugin marketplace",
-    "version": "2.0.0"
-  },
-  "plugins": [
-    {
-      "name": "ck",
-      "description": "Cavekit framework with skills, commands, agents, and references",
-      "version": "2.0.0",
-      "source": "./ck",
-      "author": { "name": "$(whoami)" }
-    },
-    {
-      "name": "bp",
-      "description": "[DEPRECATED — use /ck:* instead] Cavekit framework (legacy alias)",
-      "version": "2.0.0",
-      "source": "./bp",
-      "author": { "name": "$(whoami)" }
-    }
-  ]
-}
-EOF
-
-cat > "$MARKETPLACE_DIR/.claude-plugin/plugin.json" <<EOF
-{
-  "name": "cavekit-marketplace",
-  "description": "Local Cavekit plugin marketplace",
-  "version": "2.0.0",
-  "plugins": ["ck", "bp"]
-}
-EOF
-
-ok "Marketplace created at $MARKETPLACE_DIR"
-
-# ─── Register Claude Code plugin ───────────────────────────────────────────
-
-info "Configuring Claude Code settings..."
-
-mkdir -p "$CLAUDE_DIR"
-
-if [[ ! -f "$SETTINGS_FILE" ]]; then
-  cat > "$SETTINGS_FILE" <<EOF
-{
-  "extraKnownMarketplaces": {
-    "${MARKETPLACE_NAME}": {
-      "source": { "source": "directory", "path": "${MARKETPLACE_DIR}" }
-    }
-  },
-  "enabledPlugins": {
-    "ck@${MARKETPLACE_NAME}": true,
-    "bp@${MARKETPLACE_NAME}": true
-  }
-}
-EOF
-  ok "Created $SETTINGS_FILE"
-else
-  if grep -q "ck@${MARKETPLACE_NAME}" "$SETTINGS_FILE" 2>/dev/null && grep -q "bp@${MARKETPLACE_NAME}" "$SETTINGS_FILE" 2>/dev/null; then
-    ok "Plugin already registered"
-  else
-    if command -v python3 &>/dev/null; then
-      python3 - "$SETTINGS_FILE" "$MARKETPLACE_NAME" "$MARKETPLACE_DIR" <<'PYEOF'
-import json, sys
-path, name, mpath = sys.argv[1], sys.argv[2], sys.argv[3]
-with open(path) as f:
-    d = json.load(f)
-d.setdefault("extraKnownMarketplaces", {})[name] = {"source": {"source": "directory", "path": mpath}}
-d.setdefault("enabledPlugins", {})[f"ck@{name}"] = True
-d.setdefault("enabledPlugins", {})[f"bp@{name}"] = True
-with open(path, "w") as f:
-    json.dump(d, f, indent=2)
-PYEOF
-      ok "Updated $SETTINGS_FILE"
-    else
-      warn "Could not auto-update settings. Add manually to $SETTINGS_FILE:"
-      printf "\n"
-      printf '  "extraKnownMarketplaces": { "%s": { "source": { "source": "directory", "path": "%s" } } }\n' "$MARKETPLACE_NAME" "$MARKETPLACE_DIR"
-      printf '  "enabledPlugins": { "ck@%s": true, "bp@%s": true }\n\n' "$MARKETPLACE_NAME" "$MARKETPLACE_NAME"
-    fi
-  fi
-fi
 
 # ─── Sync Codex local plugin ────────────────────────────────────────────────
 
-info "Configuring Codex local plugin..."
+info "Configuring Codex skill discovery..."
 
 chmod +x "$INSTALL_DIR/scripts/sync-codex-plugin.sh"
 "$INSTALL_DIR/scripts/sync-codex-plugin.sh"
@@ -172,15 +71,9 @@ printf "    cavekit --status                  Show build site progress\n"
 printf "    cavekit --analytics               Show loop trends\n"
 printf "    cavekit --kill                    Stop sessions\n"
 printf "\n"
-printf "  ${B}Claude:${R}\n"
-printf "    /ck:sketch                    Draft kits\n"
-printf "    /ck:map                Architect build sites\n"
-printf "    /ck:make                    Build from kits\n"
-printf "    /ck:check                  Inspect the build\n"
-printf "    /ck:progress                 Check build progress\n"
-printf "\n"
 printf "  ${B}Codex:${R}\n"
-printf "    Synced local plugin via ~/plugins/ck and ~/.agents/plugins/marketplace.json\n"
-printf "    Linked prompts into ~/.codex/prompts (for /prompts:ck-... commands)\n"
+printf "    Open this repo in Codex; skills are discoverable from .agents/skills\n"
+printf "    Invoke phases with \$ck-sketch, \$ck-map, \$ck-make, and \$ck-check\n"
+printf "    Optional: use cavekit --monitor to run Codex sessions in tmux\n"
 printf "\n"
-printf "  Restart Claude Code and Codex to load the plugin changes.\n\n"
+printf "  Restart Codex if it was already running.\n\n"

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -50,7 +50,7 @@ func (s Status) Icon() string {
 	}
 }
 
-// Instance represents one Claude Code agent working on one site.
+// Instance represents one Codex agent working on one site.
 type Instance struct {
 	Title        string    `json:"title"`
 	SitePath     string    `json:"site_path"`
@@ -71,7 +71,7 @@ type Instance struct {
 	DiffAdded   int    `json:"diff_added"`
 	DiffRemoved int    `json:"diff_removed"`
 
-	// Health check state (from .claude/health-check.json in worktree).
+	// Health check state from worktree-local build metadata.
 	HealthStatus   string `json:"health_status"`    // "healthy", "warning", "error"
 	HealthErrors   int    `json:"health_errors"`
 	HealthWarnings int    `json:"health_warnings"`

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -30,15 +30,15 @@ func TestStatus_Icon(t *testing.T) {
 }
 
 func TestNewInstance(t *testing.T) {
-	inst := NewInstance("auth", "/path/to/site.md", "claude")
+	inst := NewInstance("auth", "/path/to/site.md", "codex")
 	if inst.Title != "auth" {
 		t.Errorf("Title = %q, want %q", inst.Title, "auth")
 	}
 	if inst.Status != StatusLoading {
 		t.Errorf("Status = %v, want %v", inst.Status, StatusLoading)
 	}
-	if inst.Program != "claude" {
-		t.Errorf("Program = %q, want %q", inst.Program, "claude")
+	if inst.Program != "codex" {
+		t.Errorf("Program = %q, want %q", inst.Program, "codex")
 	}
 	if inst.CreatedAt.IsZero() {
 		t.Error("CreatedAt should not be zero")
@@ -46,7 +46,7 @@ func TestNewInstance(t *testing.T) {
 }
 
 func TestInstance_IsActive(t *testing.T) {
-	inst := NewInstance("test", "", "claude")
+	inst := NewInstance("test", "", "codex")
 
 	inst.Status = StatusRunning
 	if !inst.IsActive() {
@@ -65,7 +65,7 @@ func TestInstance_IsActive(t *testing.T) {
 }
 
 func TestInstance_ProgressString(t *testing.T) {
-	inst := NewInstance("auth", "", "claude")
+	inst := NewInstance("auth", "", "codex")
 	inst.Status = StatusRunning
 	inst.TasksDone = 3
 	inst.TasksTotal = 12
@@ -78,7 +78,7 @@ func TestInstance_ProgressString(t *testing.T) {
 }
 
 func TestInstance_ProgressString_Empty(t *testing.T) {
-	inst := NewInstance("auth", "", "claude")
+	inst := NewInstance("auth", "", "codex")
 	if got := inst.ProgressString(); got != "" {
 		t.Errorf("ProgressString() = %q, want empty", got)
 	}

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -32,7 +32,7 @@ func (m *Manager) Create(title, sitePath, siteName, program string) *Instance {
 	return inst
 }
 
-// Start creates the worktree and tmux session, then sends the build command.
+// Start creates the worktree and tmux session, then sends the initial Cavekit prompt.
 func (m *Manager) Start(ctx context.Context, inst *Instance, projectRoot, siteName string, startupDelay time.Duration) error {
 	inst.Status = StatusLoading
 
@@ -55,15 +55,19 @@ func (m *Manager) Start(ctx context.Context, inst *Instance, projectRoot, siteNa
 	if startupDelay > 0 {
 		go func() {
 			time.Sleep(startupDelay)
-			cmd := fmt.Sprintf("/ck:make --filter %s", siteName)
+			cmd := buildPrompt(siteName)
 			m.tmux.SendCommand(ctx, siteName, cmd)
 		}()
 	} else {
-		cmd := fmt.Sprintf("/ck:make --filter %s", siteName)
+		cmd := buildPrompt(siteName)
 		m.tmux.SendCommand(ctx, siteName, cmd)
 	}
 
 	return nil
+}
+
+func buildPrompt(siteName string) string {
+	return fmt.Sprintf("$ck-make for the build site named %s. Continue the Cavekit build loop for that site only, validate each task against the relevant kits, and keep progress artifacts up to date.", siteName)
 }
 
 // Pause detaches an instance from TUI tracking (session keeps running).

--- a/internal/session/lifecycle_test.go
+++ b/internal/session/lifecycle_test.go
@@ -33,7 +33,7 @@ func newTestManager() (*Manager, *exec.MockExecutor) {
 
 func TestManager_Create(t *testing.T) {
 	mgr, _ := newTestManager()
-	inst := mgr.Create("auth", "/path/site.md", "auth", "claude")
+	inst := mgr.Create("auth", "/path/site.md", "auth", "codex")
 
 	if inst.Title != "auth" {
 		t.Errorf("Title = %q", inst.Title)
@@ -51,7 +51,7 @@ func TestManager_Create(t *testing.T) {
 
 func TestManager_Start(t *testing.T) {
 	mgr, mock := newTestManager()
-	inst := mgr.Create("auth", "/path/site.md", "auth", "claude")
+	inst := mgr.Create("auth", "/path/site.md", "auth", "codex")
 
 	err := mgr.Start(context.Background(), inst, "/code/project", "auth", 0)
 	if err != nil {
@@ -65,24 +65,24 @@ func TestManager_Start(t *testing.T) {
 		t.Error("WorktreePath should be set")
 	}
 
-	// Verify tmux send-keys was called with the build command
+	// Verify tmux send-keys was called with the build prompt
 	foundBuild := false
 	for _, c := range mock.Calls {
 		if c.Name == "tmux" {
 			args := strings.Join(c.Args, " ")
-			if strings.Contains(args, "/ck:make") && strings.Contains(args, "auth") {
+			if strings.Contains(args, "$ck-make") && strings.Contains(args, "auth") {
 				foundBuild = true
 			}
 		}
 	}
 	if !foundBuild {
-		t.Error("should have sent /ck:make command to tmux")
+		t.Error("should have sent $ck-make prompt to tmux")
 	}
 }
 
 func TestManager_Pause(t *testing.T) {
 	mgr, _ := newTestManager()
-	inst := mgr.Create("auth", "", "auth", "claude")
+	inst := mgr.Create("auth", "", "auth", "codex")
 	inst.Status = StatusRunning
 
 	mgr.Pause(inst)
@@ -93,7 +93,7 @@ func TestManager_Pause(t *testing.T) {
 
 func TestManager_Kill(t *testing.T) {
 	mgr, _ := newTestManager()
-	inst := mgr.Create("auth", "", "auth", "claude")
+	inst := mgr.Create("auth", "", "auth", "codex")
 	inst.Status = StatusRunning
 
 	err := mgr.Kill(context.Background(), inst, "/code/project", false)

--- a/internal/session/persistence_test.go
+++ b/internal/session/persistence_test.go
@@ -18,7 +18,7 @@ func TestStore_SaveLoad(t *testing.T) {
 			WorktreePath: "/code/project-cavekit-auth",
 			TmuxSession:  "bp_auth",
 			Status:       StatusRunning,
-			Program:      "claude",
+			Program:      "codex",
 			CreatedAt:    time.Now(),
 			TasksDone:    3,
 			TasksTotal:   12,

--- a/internal/site/status.go
+++ b/internal/site/status.go
@@ -46,10 +46,12 @@ func ClassifySite(s *Site, statuses TaskStatusMap, worktreePath string) SiteStat
 		return SiteDone
 	}
 
-	// Check for active Ralph Loop in worktree
+	// Check for active Cavekit loop state in worktree
 	if worktreePath != "" {
-		ralphLoopPath := filepath.Join(worktreePath, ".claude", "ralph-loop.local.md")
-		if _, err := os.Stat(ralphLoopPath); err == nil {
+		if _, err := os.Stat(filepath.Join(worktreePath, ".cavekit", "loop-state.local.md")); err == nil {
+			return SiteInProgress
+		}
+		if _, err := os.Stat(filepath.Join(worktreePath, ".claude", "ralph-loop.local.md")); err == nil {
 			return SiteInProgress
 		}
 	}

--- a/internal/site/status_test.go
+++ b/internal/site/status_test.go
@@ -23,8 +23,8 @@ func TestClassifySite_Done(t *testing.T) {
 
 func TestClassifySite_InProgress(t *testing.T) {
 	tmp := t.TempDir()
-	os.MkdirAll(filepath.Join(tmp, ".claude"), 0755)
-	os.WriteFile(filepath.Join(tmp, ".claude", "ralph-loop.local.md"), []byte("active"), 0644)
+	os.MkdirAll(filepath.Join(tmp, ".cavekit"), 0755)
+	os.WriteFile(filepath.Join(tmp, ".cavekit", "loop-state.local.md"), []byte("active"), 0644)
 
 	s := &Site{
 		Tasks: []Task{{ID: "T-001"}, {ID: "T-002"}},

--- a/internal/tmux/capture_test.go
+++ b/internal/tmux/capture_test.go
@@ -17,7 +17,7 @@ func TestManager_CapturePane(t *testing.T) {
 			if !strings.Contains(args, "-p") || !strings.Contains(args, "-e") || !strings.Contains(args, "-J") {
 				t.Errorf("capture-pane missing flags, got: %s", args)
 			}
-			return exec.Result{Stdout: "$ claude\nThinking...\n", ExitCode: 0}, nil
+			return exec.Result{Stdout: "$ codex\nThinking...\n", ExitCode: 0}, nil
 		}
 		return exec.Result{ExitCode: 0}, nil
 	})
@@ -27,7 +27,7 @@ func TestManager_CapturePane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CapturePane: %v", err)
 	}
-	if content != "$ claude\nThinking...\n" {
+	if content != "$ codex\nThinking...\n" {
 		t.Errorf("content = %q, unexpected", content)
 	}
 }

--- a/internal/tmux/input_test.go
+++ b/internal/tmux/input_test.go
@@ -36,13 +36,13 @@ func TestManager_SendKeys(t *testing.T) {
 	})
 
 	mgr := NewManager(mock)
-	err := mgr.SendKeys(context.Background(), "test", "/ck:make", "Enter")
+	err := mgr.SendKeys(context.Background(), "test", "$ck-make", "Enter")
 	if err != nil {
 		t.Fatalf("SendKeys: %v", err)
 	}
 
 	args := mock.Calls[0].Args
-	// Should include: send-keys -t bp_test /ck:make Enter
+	// Should include: send-keys -t bp_test $ck-make Enter
 	if args[0] != "send-keys" {
 		t.Errorf("first arg should be send-keys, got %s", args[0])
 	}
@@ -73,7 +73,7 @@ func TestManager_SendCommand(t *testing.T) {
 	})
 
 	mgr := NewManager(mock)
-	err := mgr.SendCommand(context.Background(), "test", "/ck:make --filter auth")
+	err := mgr.SendCommand(context.Background(), "test", "$ck-make for the build site named auth")
 	if err != nil {
 		t.Fatalf("SendCommand: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestManager_SendCommand(t *testing.T) {
 	args := mock.Calls[0].Args
 	found := false
 	for _, a := range args {
-		if a == "/ck:make --filter auth" {
+		if a == "$ck-make for the build site named auth" {
 			found = true
 		}
 	}

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -1,5 +1,5 @@
 // Package tmux manages detached tmux sessions as the execution backend
-// for Claude Code instances.
+// for Cavekit agent sessions.
 package tmux
 
 import (

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -32,7 +32,7 @@ func TestManager_CreateSession(t *testing.T) {
 	})
 
 	mgr := NewManager(mock)
-	err := mgr.CreateSession(context.Background(), "test", "/tmp", "claude")
+	err := mgr.CreateSession(context.Background(), "test", "/tmp", "codex")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}

--- a/internal/tmux/status.go
+++ b/internal/tmux/status.go
@@ -12,8 +12,8 @@ type PaneStatus int
 
 const (
 	PaneUnknown PaneStatus = iota
-	PaneActive             // Content is changing (Claude is working)
-	PanePrompt             // Claude is waiting for permission approval
+	PaneActive             // Content is changing (the agent is working)
+	PanePrompt             // The agent is waiting for permission approval or input
 	PaneTrust              // Trust prompt ("Do you trust the files...")
 	PaneIdle               // Content hasn't changed (might be waiting for input)
 )
@@ -33,12 +33,13 @@ func (s PaneStatus) String() string {
 	}
 }
 
-// Permission prompt markers in Claude Code output.
+// Permission prompt markers commonly surfaced by coding-agent CLIs.
 var permissionPromptMarkers = []string{
-	"No, and tell Claude what to do differently",
+	"No, and tell Codex what to do differently",
 	"Allow once",
 	"Allow always",
 	"(Y)es",
+	"Approve this action",
 }
 
 // Trust prompt markers.

--- a/internal/tmux/status_test.go
+++ b/internal/tmux/status_test.go
@@ -64,7 +64,7 @@ func TestStatusDetector_Prompt(t *testing.T) {
 	mock := exec.NewMockExecutor()
 	mock.OnCommand("tmux", func(c exec.Call) (exec.Result, error) {
 		return exec.Result{
-			Stdout:   "Claude wants to edit file.go\nAllow once\nNo, and tell Claude what to do differently\n",
+			Stdout:   "Codex wants to edit file.go\nAllow once\nNo, and tell Codex what to do differently\n",
 			ExitCode: 0,
 		}, nil
 	})

--- a/internal/tmux/terminal.go
+++ b/internal/tmux/terminal.go
@@ -3,38 +3,18 @@ package tmux
 import (
 	"os/exec"
 
-	"golang.org/x/sys/unix"
+	"github.com/charmbracelet/x/term"
 )
 
 // makeRaw sets the terminal to raw mode and returns the original state.
-func makeRaw(fd uintptr) (*unix.Termios, error) {
-	termios, err := unix.IoctlGetTermios(int(fd), unix.TIOCGETA)
-	if err != nil {
-		return nil, err
-	}
-
-	oldState := *termios
-
-	// Set raw mode
-	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
-	termios.Oflag &^= unix.OPOST
-	termios.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
-	termios.Cflag &^= unix.CSIZE | unix.PARENB
-	termios.Cflag |= unix.CS8
-	termios.Cc[unix.VMIN] = 1
-	termios.Cc[unix.VTIME] = 0
-
-	if err := unix.IoctlSetTermios(int(fd), unix.TIOCSETA, termios); err != nil {
-		return nil, err
-	}
-
-	return &oldState, nil
+func makeRaw(fd uintptr) (*term.State, error) {
+	return term.MakeRaw(fd)
 }
 
 // restoreTerminal restores the terminal to its original state.
-func restoreTerminal(fd uintptr, state *unix.Termios) {
+func restoreTerminal(fd uintptr, state *term.State) {
 	if state != nil {
-		unix.IoctlSetTermios(int(fd), unix.TIOCSETA, state)
+		_ = term.Restore(fd, state)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -560,7 +560,7 @@ func (a *App) createInstanceCmd(name string) tea.Cmd {
 	return func() tea.Msg {
 		prog := a.program
 		if prog == "" {
-			prog = "claude"
+			prog = "codex"
 		}
 		inst := a.sessionMgr.Create(name, "", name, prog)
 		err := a.sessionMgr.Start(context.Background(), inst, a.projectRoot, name, 3*time.Second)
@@ -622,7 +622,7 @@ func (a *App) launchSites(items []SitePickerItem) tea.Cmd {
 	return func() tea.Msg {
 		prog := a.program
 		if prog == "" {
-			prog = "claude"
+			prog = "codex"
 		}
 		item := items[0]
 		inst := a.sessionMgr.Create(item.Name, item.Path, item.Name, prog)

--- a/internal/tui/tier3_test.go
+++ b/internal/tui/tier3_test.go
@@ -13,7 +13,7 @@ import (
 func TestPreviewTab_Content(t *testing.T) {
 	mock := exec.NewMockExecutor()
 	mock.OnCommand("tmux", func(c exec.Call) (exec.Result, error) {
-		return exec.Result{Stdout: "$ claude\nWorking...\n", ExitCode: 0}, nil
+		return exec.Result{Stdout: "$ codex\nWorking...\n", ExitCode: 0}, nil
 	})
 	mgr := tmux.NewManager(mock)
 	preview := NewPreviewTab(mgr)

--- a/internal/worktree/discover.go
+++ b/internal/worktree/discover.go
@@ -10,8 +10,8 @@ import (
 type DiscoveredWorktree struct {
 	Path         string // Full worktree path
 	Branch       string // Branch name (cavekit/xxx)
-	SiteName string // Derived site name
-	HasRalphLoop bool   // .claude/ralph-loop.local.md exists
+	SiteName     string // Derived site name
+	HasRalphLoop bool   // Cavekit loop state file exists
 }
 
 // DiscoverAll finds all existing Cavekit worktrees for the given project.
@@ -39,14 +39,14 @@ func DiscoverAll(projectRoot string) ([]DiscoveredWorktree, error) {
 		siteName := strings.TrimPrefix(name, pattern)
 		wtPath := filepath.Join(parentDir, name)
 
-		// Check for active Ralph Loop
-		ralphLoopPath := filepath.Join(wtPath, ".claude", "ralph-loop.local.md")
-		hasRalphLoop := fileExists(ralphLoopPath)
+		// Check for active Cavekit loop state
+		hasRalphLoop := fileExists(filepath.Join(wtPath, ".cavekit", "loop-state.local.md")) ||
+			fileExists(filepath.Join(wtPath, ".claude", "ralph-loop.local.md"))
 
 		results = append(results, DiscoveredWorktree{
 			Path:         wtPath,
 			Branch:       BranchName(siteName),
-			SiteName: siteName,
+			SiteName:     siteName,
 			HasRalphLoop: hasRalphLoop,
 		})
 	}

--- a/internal/worktree/discover_test.go
+++ b/internal/worktree/discover_test.go
@@ -18,9 +18,9 @@ func TestDiscoverAll(t *testing.T) {
 
 	wt2 := filepath.Join(parent, "myproject-cavekit-payments")
 	os.MkdirAll(wt2, 0755)
-	// Add ralph loop marker to payments
-	os.MkdirAll(filepath.Join(wt2, ".claude"), 0755)
-	os.WriteFile(filepath.Join(wt2, ".claude", "ralph-loop.local.md"), []byte("active"), 0644)
+	// Add loop state marker to payments
+	os.MkdirAll(filepath.Join(wt2, ".cavekit"), 0755)
+	os.WriteFile(filepath.Join(wt2, ".cavekit", "loop-state.local.md"), []byte("active"), 0644)
 
 	// Non-cavekit dir (should be excluded)
 	os.MkdirAll(filepath.Join(parent, "myproject-other"), 0755)

--- a/scripts/cavekit
+++ b/scripts/cavekit
@@ -36,6 +36,15 @@ count_frontier_tasks() {
     | tr -d ' '
 }
 
+find_loop_state_file() {
+  local project_root="$1"
+  if [[ -f "$project_root/.cavekit/loop-state.local.md" ]]; then
+    echo "$project_root/.cavekit/loop-state.local.md"
+  elif [[ -f "$project_root/.claude/ralph-loop.local.md" ]]; then
+    echo "$project_root/.claude/ralph-loop.local.md"
+  fi
+}
+
 SCRIPT_DIR="$(resolve_script_dir)"
 
 usage() {
@@ -89,11 +98,13 @@ do_status() {
 
     # Check loop state
     local status_icon="·"
-    if [[ -f "$PROJECT_ROOT/.claude/ralph-loop.local.md" ]]; then
+    local state_file
+    state_file="$(find_loop_state_file "$PROJECT_ROOT")"
+    if [[ -n "$state_file" ]]; then
       local iter
-      iter=$(grep -m1 '^iteration:' "$PROJECT_ROOT/.claude/ralph-loop.local.md" 2>/dev/null | awk '{print $2}' || echo "?")
+      iter=$(grep -m1 '^iteration:' "$state_file" 2>/dev/null | awk '{print $2}' || echo "?")
       local max_iter
-      max_iter=$(grep -m1 '^max_iterations:' "$PROJECT_ROOT/.claude/ralph-loop.local.md" 2>/dev/null | awk '{print $2}' || echo "?")
+      max_iter=$(grep -m1 '^max_iterations:' "$state_file" 2>/dev/null | awk '{print $2}' || echo "?")
       status_icon="⟳ iter ${iter}/${max_iter},"
     elif [[ "$total" -gt 0 && "$done_count" -ge "$total" ]]; then
       status_icon="✓"
@@ -124,7 +135,7 @@ do_kill() {
   # Clean stale ralph-loop state from main project
   local PROJECT_ROOT
   PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  rm -f "$PROJECT_ROOT/.claude/ralph-loop.local.md"
+  rm -f "$PROJECT_ROOT/.cavekit/loop-state.local.md" "$PROJECT_ROOT/.claude/ralph-loop.local.md"
 
   echo "Killed $KILLED sessions."
 }

--- a/scripts/cavekit
+++ b/scripts/cavekit
@@ -138,7 +138,7 @@ do_monitor() {
   fi
 
   command -v tmux &>/dev/null || { echo "tmux not found. Install: brew install tmux" >&2; exit 1; }
-  command -v claude &>/dev/null || { echo "claude not found." >&2; exit 1; }
+  command -v codex &>/dev/null || { echo "codex not found." >&2; exit 1; }
 
   # Ensure dependencies are installed
   if [[ ! -d "$SCRIPT_DIR/node_modules/@inquirer" ]]; then

--- a/scripts/cavekit-analytics.sh
+++ b/scripts/cavekit-analytics.sh
@@ -189,8 +189,14 @@ echo ""
 # ─── Active Agents ────────────────────────────────────────────────────────────
 
 echo "${B}Active Agent${R}"
-if [[ -f "$PROJECT_ROOT/.claude/ralph-loop.local.md" ]]; then
-  iter=$(grep -m1 '^iteration:' "$PROJECT_ROOT/.claude/ralph-loop.local.md" 2>/dev/null | awk '{print $2}' || echo "?")
+STATE_FILE=""
+if [[ -f "$PROJECT_ROOT/.cavekit/loop-state.local.md" ]]; then
+  STATE_FILE="$PROJECT_ROOT/.cavekit/loop-state.local.md"
+elif [[ -f "$PROJECT_ROOT/.claude/ralph-loop.local.md" ]]; then
+  STATE_FILE="$PROJECT_ROOT/.claude/ralph-loop.local.md"
+fi
+if [[ -n "$STATE_FILE" ]]; then
+  iter=$(grep -m1 '^iteration:' "$STATE_FILE" 2>/dev/null | awk '{print $2}' || echo "?")
   echo "  ${GR}⟳${R} active — iteration ${iter}"
 else
   echo "  ${D}No active agent.${R}"

--- a/scripts/cavekit-analytics.sh
+++ b/scripts/cavekit-analytics.sh
@@ -36,7 +36,7 @@ for archive_log in "$PROJECT_ROOT"/context/impl/archive/*/loop-log.md; do
 done
 
 if [[ ${#LOGS[@]} -eq 0 ]]; then
-  echo "No loop logs found. Run /ck:make first."
+  echo "No loop logs found. Run \$ck-make first."
   exit 0
 fi
 

--- a/scripts/cavekit-launch-session.sh
+++ b/scripts/cavekit-launch-session.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # cavekit-launch-session — Creates a tmux session with one pane per build site.
-# Each pane runs Claude in the project directory with /ck:make.
+# Each pane runs Codex in the project directory and then receives a $ck-make prompt.
 #
 # Usage: cavekit-launch-session.sh [--expanded] <frontier-path> [<frontier-path> ...]
 #
@@ -32,7 +32,7 @@ fi
 # ─── Preflight ────────────────────────────────────────────────────────────────
 
 command -v tmux &>/dev/null || { echo "tmux not found. Install: brew install tmux" >&2; exit 1; }
-command -v claude &>/dev/null || { echo "claude not found." >&2; exit 1; }
+command -v codex &>/dev/null || { echo "codex not found." >&2; exit 1; }
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -80,10 +80,10 @@ write_launcher() {
   local frontier_basename
   frontier_basename=$(basename "$frontier_path")
 
-  local claude_cmd="claude"
+  local agent_cmd="codex"
   local mode_label="NEW"
   if [[ "$resuming" == "true" ]]; then
-    claude_cmd="claude --resume"
+    agent_cmd="codex resume --last"
     mode_label="RESUME"
   fi
 
@@ -95,7 +95,7 @@ echo "Cavekit Agent: $name [$mode_label]"
 echo "Directory: $project_dir"
 echo "Frontier: $frontier_basename"
 echo ""
-$claude_cmd
+$agent_cmd
 LAUNCHER_EOF
   chmod +x "$launcher"
   echo "$launcher"
@@ -181,16 +181,16 @@ else
   tmux select-pane -t "$SESSION_NAME:0.0"
 fi
 
-# ─── Staggered /ck:make launch ──────────────────────────────────────
+# ─── Staggered $ck-make launch ──────────────────────────────────────
 
-# Background process that sends /ck:make to NEW panes (resumed ones already have context)
+# Background process that sends the Codex-native Cavekit prompt to NEW panes.
 (
-  sleep 3  # Wait for Claude instances to start
+  sleep 3  # Wait for Codex instances to start
 
   for i in "${!NAMES[@]}"; do
     name="${NAMES[$i]}"
 
-    # Resumed sessions already have their loop — skip sending /ck:make
+    # Resumed sessions already have their loop — skip sending the initial prompt
     if [[ "${RESUMING[$i]}" == "true" ]]; then
       continue
     fi
@@ -201,7 +201,7 @@ fi
       target="$SESSION_NAME:0.${i}"
     fi
 
-    tmux send-keys -t "$target" "/ck:make --filter ${name}" Enter
+    tmux send-keys -t "$target" "\$ck-make for the build site named ${name}. Continue the Cavekit build loop for that site only, validate each task against the relevant kits, and keep progress artifacts up to date." Enter
 
     # Stagger between launches (skip delay after last one)
     sleep "$STAGGER_DELAY"

--- a/scripts/cavekit-launch-session.sh
+++ b/scripts/cavekit-launch-session.sh
@@ -36,6 +36,15 @@ command -v codex &>/dev/null || { echo "codex not found." >&2; exit 1; }
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
+loop_state_file() {
+  local project_root="$1"
+  if [[ -f "$project_root/.cavekit/loop-state.local.md" ]]; then
+    echo "$project_root/.cavekit/loop-state.local.md"
+  elif [[ -f "$project_root/.claude/ralph-loop.local.md" ]]; then
+    echo "$project_root/.claude/ralph-loop.local.md"
+  fi
+}
+
 # Kill existing session if running
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
   echo "Existing '$SESSION_NAME' session found. Killing it..."
@@ -58,7 +67,7 @@ for frontier in "${FRONTIERS[@]}"; do
   NAMES+=("$name")
 
   # Check if this is a resumable session (has ralph-loop state or impl progress)
-  if [[ -f "$PROJECT_ROOT/.claude/ralph-loop.local.md" ]] || \
+  if [[ -n "$(loop_state_file "$PROJECT_ROOT")" ]] || \
      ls "$PROJECT_ROOT/context/impl/impl-"*.md &>/dev/null 2>&1; then
     RESUMING+=("true")
     echo "  $name: will resume existing session"

--- a/scripts/cavekit-picker.ts
+++ b/scripts/cavekit-picker.ts
@@ -157,8 +157,9 @@ function detectStatus(
   const worktreePath = resolve(projectRoot, `../${projectName}-cavekit-${name}`);
   if (existsSync(worktreePath)) {
     // Check if ralph loop is active in the worktree
-    const ralphState = join(worktreePath, ".claude/ralph-loop.local.md");
-    if (existsSync(ralphState)) return "in-progress";
+    const loopState = join(worktreePath, ".cavekit/loop-state.local.md");
+    const legacyLoopState = join(worktreePath, ".claude/ralph-loop.local.md");
+    if (existsSync(loopState) || existsSync(legacyLoopState)) return "in-progress";
     // Worktree exists but no active loop — could be finished or stale
     if (doneTasks > 0) return "in-progress";
   }

--- a/scripts/cavekit-picker.ts
+++ b/scripts/cavekit-picker.ts
@@ -185,7 +185,7 @@ async function main() {
 
   if (frontiers.length === 0) {
     console.error("No frontiers found in context/plans/ or context/sites/");
-    console.error("Run /ck:map first to generate one.");
+    console.error("Run $ck-map first to generate one.");
     process.exit(1);
   }
 

--- a/scripts/cavekit-status-poller.sh
+++ b/scripts/cavekit-status-poller.sh
@@ -11,6 +11,15 @@ TASK_ID_PATTERN='T-([A-Za-z0-9]+-)*[A-Za-z0-9]+'
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
+loop_state_file() {
+  local project_root="$1"
+  if [[ -f "$project_root/.cavekit/loop-state.local.md" ]]; then
+    echo "$project_root/.cavekit/loop-state.local.md"
+  elif [[ -f "$project_root/.claude/ralph-loop.local.md" ]]; then
+    echo "$project_root/.claude/ralph-loop.local.md"
+  fi
+}
+
 # Wait for session to exist
 for _ in {1..10}; do
   tmux has-session -t "$SESSION_NAME" 2>/dev/null && break
@@ -63,7 +72,7 @@ get_status_icon() {
     return
   fi
 
-  if [[ -f "$project_dir/.claude/ralph-loop.local.md" ]]; then
+  if [[ -n "$(loop_state_file "$project_dir")" ]]; then
     echo "⟳"
   else
     echo "○"

--- a/scripts/codex-design-challenge.sh
+++ b/scripts/codex-design-challenge.sh
@@ -482,7 +482,7 @@ bp_design_challenge_cycle() {
 }
 
 # ── T-306: Draft Flow Integration Point ───────────────────────────────
-# Entry point for the /ck:sketch command to call after Step 8 (cavekit-reviewer).
+# Entry point for the $ck-sketch skill flow to call after Step 8 (cavekit-reviewer).
 # Runs the design challenge and returns results for insertion before Step 9 (user gate).
 #
 # Arguments:

--- a/scripts/codex-detect.sh
+++ b/scripts/codex-detect.sh
@@ -29,11 +29,11 @@ CODEX_PLUGIN_PRESENT=false
 
 # Check legacy plugin and current Codex config locations
 _bp_check_codex_plugin() {
-  local claude_dir="${HOME}/.claude"
+  local legacy_plugin_dir="${HOME}/.claude"
 
   # Check plugins cache (marketplace installs)
-  if [[ -d "${claude_dir}/plugins" ]]; then
-    for d in "${claude_dir}/plugins/"*/; do
+  if [[ -d "${legacy_plugin_dir}/plugins" ]]; then
+    for d in "${legacy_plugin_dir}/plugins/"*/; do
       [[ -d "$d" ]] || continue
       if [[ -d "${d}codex" ]] || [[ -d "${d}openai-codex" ]] || \
          find "$d" -maxdepth 2 -name "plugin.json" -exec grep -ql "codex" {} + 2>/dev/null | grep -q .; then
@@ -43,8 +43,8 @@ _bp_check_codex_plugin() {
   fi
 
   # Check local plugin links
-  if [[ -d "${claude_dir}/plugins/local" ]]; then
-    for d in "${claude_dir}/plugins/local/"*/; do
+  if [[ -d "${legacy_plugin_dir}/plugins/local" ]]; then
+    for d in "${legacy_plugin_dir}/plugins/local/"*/; do
       [[ -d "$d" ]] || continue
       if find "$d" -maxdepth 2 -name "*.json" -exec grep -ql "codex" {} + 2>/dev/null | grep -q .; then
         return 0

--- a/scripts/codex-detect.sh
+++ b/scripts/codex-detect.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# codex-detect.sh — Codex binary and plugin detection utilities
+# codex-detect.sh — Codex binary and local integration detection utilities
 # Source this file from other scripts: source "$(dirname "$0")/codex-detect.sh"
 #
 # Provides:
 #   CODEX_BINARY_AVAILABLE  (true/false) — codex binary on PATH and responsive
-#   CODEX_PLUGIN_PRESENT    (true/false) — Codex Claude Code plugin installed
-#   codex_available         (true/false) — both binary AND plugin present
+#   CODEX_PLUGIN_PRESENT    (true/false) — local Codex integration/config detected
+#   codex_available         (true/false) — Codex is available for Cavekit workflows
 #   bp_codex_nudge          — one-time install suggestion (no-op if already shown)
 
 # Guard against double-sourcing
@@ -23,11 +23,11 @@ if command -v codex &>/dev/null; then
   fi
 fi
 
-# ── Plugin presence check (T-002) ──────────────────────────────────────
+# ── Local integration check (T-002) ────────────────────────────────────
 
 CODEX_PLUGIN_PRESENT=false
 
-# Check standard Claude Code plugin locations
+# Check legacy plugin and current Codex config locations
 _bp_check_codex_plugin() {
   local claude_dir="${HOME}/.claude"
 
@@ -90,7 +90,7 @@ bp_codex_nudge() {
     echo "Tip: Install Codex for adversarial code review: npm install -g @openai/codex" >&2
   fi
   if [[ "$CODEX_PLUGIN_PRESENT" != "true" && "$CODEX_BINARY_AVAILABLE" == "true" ]]; then
-    echo "Tip: Codex binary found but plugin not detected. Run: codex setup" >&2
+    echo "Tip: Codex binary found but no local Codex integration was detected. Run: codex setup" >&2
   fi
 
   touch "$_BP_NUDGE_FILE"

--- a/scripts/command-gate.sh
+++ b/scripts/command-gate.sh
@@ -6,7 +6,7 @@
 # T-102: Built-in allowlist and blocklist
 # T-103: Configuration schema and defaults
 # T-104: Fast-path classifier
-# T-105: Claude permission integration
+# T-105: Agent permission integration
 # T-106: Command normalizer
 # T-107: Codex safety classification
 # T-108: Pattern-based verdict cache
@@ -343,20 +343,20 @@ Working directory: ${workdir}"
   esac
 }
 
-# ── T-105: Claude Permission Integration ──────────────────────────────
-# Check if the command is already handled by Claude's permission system.
+# ── T-105: Agent Permission Integration ───────────────────────────────
+# Check if the command is already handled by the runtime permission system.
 # This is signaled via environment variables set by the hook framework.
 #
 # BP_HOOK_ALREADY_ALLOWED=1  — command pre-approved in settings
 # BP_HOOK_ALREADY_BLOCKED=1  — command pre-blocked in settings
 
-bp_gate_check_claude_permissions() {
+bp_gate_check_runtime_permissions() {
   if [[ "${BP_HOOK_ALREADY_ALLOWED:-}" == "1" ]]; then
-    echo "SKIP|Already allowed by Claude permission system"
+    echo "SKIP|Already allowed by runtime permission system"
     return 0
   fi
   if [[ "${BP_HOOK_ALREADY_BLOCKED:-}" == "1" ]]; then
-    echo "SKIP|Already blocked by Claude permission system"
+    echo "SKIP|Already blocked by runtime permission system"
     return 0
   fi
   echo "EVALUATE"
@@ -365,7 +365,7 @@ bp_gate_check_claude_permissions() {
 # ── T-101: PreToolUse Hook Main Entry ─────────────────────────────────
 # Called as a PreToolUse hook. Reads tool call context, classifies command.
 #
-# Input (from Claude Code hook framework):
+# Input (from the agent hook framework):
 #   $1 — tool name (should be "Bash")
 #   $2 — command string
 # Or reads JSON from stdin with tool_name and input.command
@@ -404,9 +404,9 @@ bp_command_gate() {
     return 0
   fi
 
-  # T-105: Check Claude's permission system first
+  # T-105: Check the runtime permission system first
   local perm_check
-  perm_check="$(bp_gate_check_claude_permissions)"
+  perm_check="$(bp_gate_check_runtime_permissions)"
   if [[ "$perm_check" == SKIP* ]]; then
     return 0
   fi

--- a/scripts/dashboard-activity.sh
+++ b/scripts/dashboard-activity.sh
@@ -118,7 +118,7 @@ render() {
 
   [[ -n "$current_task" ]] && emit "  ${YL}>${R} Working on ${B}${current_task}${R}" && emit ""
 
-  if [[ ! -f ".claude/ralph-loop.local.md" ]]; then
+  if [[ ! -f ".cavekit/loop-state.local.md" && ! -f ".claude/ralph-loop.local.md" ]]; then
     emit "  ${D}Loop not active${R}"
   fi
 

--- a/scripts/dashboard-progress.sh
+++ b/scripts/dashboard-progress.sh
@@ -62,8 +62,9 @@ render() {
   emit "${B}${BL} CAVEKIT${R}"
   emit "${BL}${D}${hr}${R}"
 
-  # ── Ralph Loop state ──
-  local state_file=".claude/ralph-loop.local.md"
+  # ── Loop state ──
+  local state_file=".cavekit/loop-state.local.md"
+  [[ -f "$state_file" ]] || state_file=".claude/ralph-loop.local.md"
   local iteration="-" max_iter="-" started_at="" active=false
 
   if [[ -f "$state_file" ]]; then

--- a/scripts/setup-build.sh
+++ b/scripts/setup-build.sh
@@ -111,7 +111,7 @@ echo "$BP_PRESET_SUMMARY"
 
 # ─── Clean stale state ──────────────────────────────────────────────────────
 
-rm -f .claude/ralph-loop.local.md
+rm -f .cavekit/loop-state.local.md .claude/ralph-loop.local.md
 
 # ─── Find build site ────────────────────────────────────────────────────────
 #
@@ -539,11 +539,11 @@ which existing code satisfies which criterion — with file paths and line numbe
 5. Commit after each task
 6. NEVER skip implementation because code 'looks related'"
 
-# ─── Write Ralph Loop state ─────────────────────────────────────────────────
+# ─── Write Cavekit loop state ───────────────────────────────────────────────
 
-mkdir -p .claude
+mkdir -p .cavekit
 
-cat > .claude/ralph-loop.local.md <<EOF
+cat > .cavekit/loop-state.local.md <<EOF
 ---
 active: true
 iteration: 1

--- a/scripts/setup-build.sh
+++ b/scripts/setup-build.sh
@@ -90,7 +90,7 @@ HELP_EOF
       ;;
     *)
       # Positional argument: treat as explicit file path
-      # Strip leading @ (Claude Code convention)
+      # Strip leading @ for compatibility with older prompt-style examples
       arg="${1#@}"
       if [[ -n "$EXPLICIT_FILE" ]]; then
         echo "❌ Unexpected argument: $1 (file already set to $EXPLICIT_FILE)" >&2
@@ -178,7 +178,7 @@ fi
 
 if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
   echo "❌ No build site or plan found in context/plans/ or context/sites/" >&2
-  echo "   Run /ck:map first to generate one." >&2
+  echo "   Run \$ck-map first to generate one." >&2
   exit 1
 fi
 

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -7,7 +7,7 @@ PLUGIN_NAME="ck"
 PLUGIN_DIR="$HOME/plugins/$PLUGIN_NAME"
 MARKETPLACE_FILE="$HOME/.agents/plugins/marketplace.json"
 LEGACY_LINK="$HOME/.codex/cavekit"
-PROMPTS_DIR="$HOME/.codex/prompts"
+SKILLS_LINK="$HOME/.agents/skills/cavekit"
 
 R=$'\033[0m' B=$'\033[1m' GR=$'\033[32m' YL=$'\033[33m' BL=$'\033[34m' RD=$'\033[31m'
 
@@ -18,9 +18,9 @@ fail()  { printf "${RD}✗${R} %s\n" "$1" >&2; exit 1; }
 
 command -v python3 &>/dev/null || fail "python3 not found."
 
-info "Syncing Cavekit into Codex local plugins..."
+info "Syncing Cavekit into Codex local plugins and skills..."
 
-mkdir -p "$HOME/plugins" "$(dirname "$MARKETPLACE_FILE")" "$PROMPTS_DIR"
+mkdir -p "$HOME/plugins" "$(dirname "$MARKETPLACE_FILE")" "$(dirname "$SKILLS_LINK")"
 ln -sfn "$ROOT_DIR" "$PLUGIN_DIR"
 ok "Linked plugin at $PLUGIN_DIR"
 
@@ -31,27 +31,12 @@ else
   warn "Skipping legacy ~/.codex symlink because ~/.codex does not exist"
 fi
 
-for command_file in "$ROOT_DIR"/commands/*.md; do
-  command_name="$(basename "$command_file" .md)"
-  # Primary ck- prefix
-  ln -sfn "$command_file" "$PROMPTS_DIR/ck-$command_name.md"
-  # Deprecated bp- alias
-  ln -sfn "$command_file" "$PROMPTS_DIR/bp-$command_name.md"
-done
-
-# Clean up stale prompts for both prefixes
-for prefix in ck bp; do
-  for prompt_path in "$PROMPTS_DIR"/${prefix}-*.md; do
-    [[ -e "$prompt_path" || -L "$prompt_path" ]] || continue
-    prompt_name="$(basename "$prompt_path")"
-    command_name="${prompt_name#${prefix}-}"
-    command_name="${command_name%.md}"
-    if [[ ! -f "$ROOT_DIR/commands/$command_name.md" ]]; then
-      rm -f "$prompt_path"
-    fi
-  done
-done
-ok "Linked Codex prompts at $PROMPTS_DIR"
+if [[ -d "$ROOT_DIR/.agents/skills" ]]; then
+  ln -sfn "$ROOT_DIR/.agents/skills" "$SKILLS_LINK"
+  ok "Linked Cavekit skills at $SKILLS_LINK"
+else
+  warn "No .agents/skills directory found in the repo; Codex skill discovery will rely on the repo checkout only"
+fi
 
 python3 - "$MARKETPLACE_FILE" <<'PYEOF'
 import json


### PR DESCRIPTION
## Summary
This PR repositions this fork of Cavekit as a Codex-first project while preserving upstream workflow structure and intent as closely as possible.

It does three main things:
- makes Codex the default runtime surface and adds explicit `$ck-*` skills
- rewires install/runtime/docs away from Claude-first assumptions and toward proven Codex CLI capabilities
- cleans up the most visible remaining legacy naming, including the active loop state path and `Ralph Loop` terminology

## What changed
- Added repo-local Codex skills under `.agents/skills/` for:
  - `ck-research`
  - `ck-design`
  - `ck-sketch`
  - `ck-map`
  - `ck-make`
  - `ck-check`
- Switched the launcher/runtime default from `claude` to `codex`
- Changed tmux session startup to inject a Codex-native `$ck-make ...` prompt instead of `/ck:make`
- Updated install/setup to point at this fork and link Cavekit into Codex-discoverable local paths
- Reworked README, examples, command docs, and core internal specs to present `$ck-*` as the canonical public interface
- Migrated the active loop state marker to `.cavekit/loop-state.local.md`
- Kept legacy `.claude/ralph-loop.local.md` reads as compatibility fallbacks
- Tightened remaining visible legacy naming from `Ralph Loop` to `build loop` / `loop state`

## Verification
- Smoke-tested the intended user flow in Codex locally:
  - `$ck-sketch`
  - `$ck-map`
  - `cavekit --monitor`
- Ran:
  - `go test ./...`

## Follow-up
A later pass can clean up the remaining internal `bp_*` namespace. I intentionally left that for a separate refactor so this PR stays focused on the Codex-first migration itself.