### PR TITLE
fix: Correct permission issue on /ck:judge and /ck:make

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -2,7 +2,7 @@
 name: ck-config
 description: Show or update Cavekit execution model presets
 argument-hint: "[list | preset <expensive|quality|balanced|fast> [--global]]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)"]
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh*)"]
 ---
 
 > **Note:** `/bp:config` is deprecated and will be removed in a future version. Use `/ck:config` instead.

--- a/commands/judge.md
+++ b/commands/judge.md
@@ -2,7 +2,7 @@
 name: ck-judge
 description: "Invoke Codex adversarial review on demand — diffs current tier against worktree base and outputs findings"
 argument-hint: "[--base REF]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/codex-review.sh:*)"]
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/codex-review.sh*)"]
 ---
 
 > **Note:** `/bp:codex-review`, `/ck:codex-review`, `/bp:judge` are deprecated aliases. Use `/ck:judge` instead.
@@ -13,11 +13,7 @@ Run an on-demand adversarial code review using the Codex CLI. This sends the cur
 
 ## Execution
 
-Run the review script, forwarding any arguments the user provided:
-
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/codex-review.sh" $ARGUMENTS
-```
+Run the review script, forwarding any arguments the user provided: `"${CLAUDE_PLUGIN_ROOT}/scripts/codex-review.sh" $ARGUMENTS`.
 
 ## Behavior
 

--- a/commands/make.md
+++ b/commands/make.md
@@ -2,18 +2,14 @@
 name: ck-make
 description: "Implement a build site or plan — automatically parallelizes independent tasks and progresses through tiers autonomously"
 argument-hint: "[FILE] [--filter PATTERN] [--peer-review] [--max-iterations N] [--completion-promise TEXT]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)", "Bash(git *)"]
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh*)", "Bash(git *)"]
 ---
 
 > **Note:** `/bp:build`, `/ck:build`, `/bp:make` are deprecated aliases. Use `/ck:make` instead.
 
 # Cavekit Build — Autonomous Implementation
 
-This is the third phase of Cavekit. Execute the setup script:
-
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh" $ARGUMENTS
-```
+This is the third phase of Cavekit. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh" $ARGUMENTS`.
 
 ## Resolve Execution Profile
 

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -2,7 +2,7 @@
 name: ck-quick
 description: "Quick end-to-end: describe a feature, get it built — draft, architect, build, and inspect without stopping"
 argument-hint: "<feature description> [--skip-inspect] [--peer-review] [--max-iterations N]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh:*)", "Bash(git *)"]
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-build.sh*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bp-config.sh*)", "Bash(git *)"]
 ---
 
 > **Note:** `/bp:quick` is deprecated and will be removed in a future version. Use `/ck:quick` instead.

--- a/context/kits/kit-command-gate.md
+++ b/context/kits/kit-command-gate.md
@@ -36,7 +36,7 @@ Send ambiguous commands to Codex (gpt-5.4-mini) for safety classification.
 
 ### R4: Claude Permission Integration
 Integrate with Claude Code's existing allow/block permission system rather than replacing it.
-- [ ] Commands already explicitly allowed in Claude's settings (e.g., `Bash(go test:*)`) bypass the gate entirely
+- [ ] Commands already explicitly allowed in Claude's settings (e.g., `Bash(go test *)`) bypass the gate entirely
 - [ ] Commands already explicitly blocked in Claude's settings are blocked before the gate runs
 - [ ] The gate only evaluates commands that would otherwise prompt the user for permission
 - [ ] Gate verdicts respect the same format Claude's permission system uses


### PR DESCRIPTION
Fixes #7 @cri5Castro & #9 Opened by me

## Summary

After a clean install and restart, `/ck:judge` and related commands could fail immediately with a Bash permission-check error instead of running the expected script.

## What changed

- replaced fenced ` ```! ` execution blocks in command files with normal inline `Run "..."` script instructions
- fixed `allowed-tools` entries from `Bash(...sh:*)` to `Bash(...sh*)`

## Why

The failing pattern included the leading `!` form instead of matching a normal Bash command string. Claude appears to be checking permission against the fenced command block, not just the resolved script path.

## Result

`/ck:judge` should run after install without requiring manual permission-rule tweaks, and the same fix applies to the related `setup-build.sh` and `bp-config.sh` command definitions.


## Tested 
- that it fixed the permission issue on /ck:judge and /ck:make
- Note that logs following will have ~ rather than /Users

## Output /ck:make:
```
❯ /ck:make

⏺ /ck:make loaded clean — fix confirmed for both commands. Now running the setup
  script:

⏺ Bash("~/.claude/plugins/local/cavekit-marketplace/ck/scripts/setup-bui
      ld.sh")
  ⎿  Running…

──────────────────────────────────────────────────────────────────────────────────────
 Bash command

   "~/.claude/plugins/local/cavekit-marketplace/ck/scripts/setup-buil
   d.sh"
   Run Cavekit build setup script

 This command requires approval

 Do you want to proceed?
 ❯ 1. Yes
  2.Yes, and don’t ask  : ~/.claude/plugins/local/cavekit-marketplace/ck
    again for           /scripts/setup-build.sh:*
   3. No
```

## Output /ck:judge:
```
 Bash command

   "~/.claude/plugins/local/cavekit-marketplace/ck/scripts/codex-revi
   ew.sh"
   Run Codex adversarial review

 This command requires approval

 Do you want to proceed?
 ❯ 1. Yes
  2.Yes, and don’t ask  : ~/.claude/plugins/local/cavekit-marketplace/ck
    again for           /scripts/codex-review.sh:*
   3. No

 Esc to cancel · Tab to amend · ctrl+e to explain
 
 ```

## Output /ck:config list
```
❯ /ck:config list

⏺ Bash("~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config
      .sh" presets)
  ⎿  Running…

──────────────────────────────────────────────────────────────────────────────────────
 Bash command

   "~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config.
   sh" presets
   List Cavekit execution presets

 This command requires approval

 Do you want to proceed?
 ❯ 1. Yes
  2.Yes, and don’t ask  : ~/.claude/plugins/local/cavekit-marketplace/ck
    again for           /scripts/bp-config.sh presets:*
   3. No
```

## Output /ck:config list
```
/ck:config

⏺ Bash("~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config
      .sh" show)
  ⎿  Running…

──────────────────────────────────────────────────────────────────────────────────────
 Bash command

   "~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config.
   sh" show
   Show effective Cavekit configuration

 This command requires approval

 Do you want to proceed?
 ❯ 1. Yes
  2.Yes, and don’t ask  : ~/.claude/plugins/local/cavekit-marketplace/ck
    again for           /scripts/bp-config.sh show:*
   3. No

 Esc to cancel · Tab to amend · ctrl+e to explain
```

### Individual script runs:

```
❯ ~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config.sh summary
Cavekit preset: quality (reasoning=opus, execution=opus, exploration=sonnet, caveman=o

❯ ~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config.sh show
bp_model_preset=quality
bp_model_preset_source=default
bp_model_preset_source_path=(built-in default)
reasoning_model=opus
execution_model=opus
exploration_model=sonnet
caveman_mode=on
caveman_phases=build,inspect
project_config=.~//Code/webviewer/.cavekit/config
global_config=~/.cavekit/config

❯ ~/.claude/plugins/local/cavekit-marketplace/ck/scripts/bp-config.sh model execution
opus
```