### PR TITLE
Remove worktree references from skills

### DIFF
--- a/skills/convergence-monitoring/SKILL.md
+++ b/skills/convergence-monitoring/SKILL.md
@@ -140,7 +140,7 @@ Iteration 4:  ██████████████████████
 |-----------|---------|-----|
 | **Fuzzy specs** | Agent interprets requirements differently each iteration | Make specs more precise; add concrete acceptance criteria |
 | **Weak validation** | Agent cannot verify correctness, so it keeps changing things | Add build/test/lint gates; strengthen acceptance criteria |
-| **Fighting sub-agents** | Multiple agents change the same code in conflicting ways | Add file ownership tables; dispatch subagents with `isolation: "worktree"` via the Agent tool |
+| **Fighting sub-agents** | Multiple agents change the same code in conflicting ways | Add file ownership tables; dispatch subagents via the Agent tool |
 | **Contradictory requirements** | Spec A says X, spec B says not-X | Resolve contradictions in specs; add explicit priority/precedence |
 | **Missing exit criteria** | Agent does not know when it is done | Add explicit exit criteria checklists and completion signals |
 | **Over-broad scope** | Too much work for one prompt/iteration | Split into smaller, focused prompts with clear boundaries |
@@ -369,7 +369,7 @@ Do not keep running. More iterations will not help.
 |-----------|-----|
 | Fuzzy specs | Rewrite ambiguous requirements with concrete acceptance criteria |
 | Weak validation | Add build/test/lint gates to the prompt |
-| File conflicts | Add file ownership tables; dispatch subagents with `isolation: "worktree"` via the Agent tool |
+| File conflicts | Add file ownership tables; dispatch subagents via the Agent tool |
 | Over-broad scope | Split into smaller prompts; reduce concurrent agents |
 | External dependency | Mock the dependency; or resolve it before resuming |
 

--- a/skills/prompt-pipeline/SKILL.md
+++ b/skills/prompt-pipeline/SKILL.md
@@ -169,16 +169,16 @@ Agent Team Structure:
   Lead (delegate mode -- never writes code directly)
   +-- Teammate A: domain-auth
   |   Owns: src/auth/*, context/impl/impl-auth.md
-  |   Dispatch: Agent tool with isolation: "worktree"
+  |   Dispatch: Agent tool
   +-- Teammate B: domain-data
   |   Owns: src/data/*, context/impl/impl-data.md
-  |   Dispatch: Agent tool with isolation: "worktree"
+  |   Dispatch: Agent tool
   +-- Teammate C: domain-ui
       Owns: src/ui/*, context/impl/impl-ui.md
-      Dispatch: Agent tool with isolation: "worktree"
+      Dispatch: Agent tool
 ```
 
-**Why:** Agents need to understand their role and what they own. Dispatch subagents with `isolation: "worktree"` via the Agent tool for filesystem isolation. After merging a subagent's branch, the caller must clean up: `git worktree remove <path>` then `git branch -D <branch>`. Claude Code only auto-cleans worktrees when agents make no changes.
+**Why:** Agents need to understand their role and what they own. Dispatch subagents via the Agent tool. After merging a subagent's branch, the caller must clean up: `git branch -D <branch>`.
 
 ### 4.3 Batching Rules
 
@@ -241,7 +241,7 @@ You are implementing {DOMAIN} for the {PROJECT_NAME} project.
 
 ### Your Role
 - You own: {FILE_PATTERNS}
-- Isolation: dispatched via Agent tool with `isolation: "worktree"`
+- Dispatched via the Agent tool
 - Your impl tracking: context/impl/impl-{DOMAIN}.md
 
 ### Context to Read First

--- a/skills/speculative-pipeline/SKILL.md
+++ b/skills/speculative-pipeline/SKILL.md
@@ -230,7 +230,7 @@ In multi-agent setups, speculative-pipeline applies at the pipeline level, not t
 Pipeline Level (speculative-pipeline timing):
   Stage 1 (Specs)     → Single agent or agent team
   Stage 2 (Plans)     → Single agent or agent team (starts after delay)
-  Stage 3 (Implement) → Agent team dispatched with `isolation: "worktree"` via Agent tool (starts after delay)
+  Stage 3 (Implement) → Agent team dispatched via Agent tool (starts after delay)
 ```
 
 Each stage can internally use agent teams (multiple teammates working in parallel on different

--- a/skills/validation-first/SKILL.md
+++ b/skills/validation-first/SKILL.md
@@ -281,7 +281,7 @@ Before reporting completion:
 
 ## Merge Protocol
 
-When working with agent teams (multiple agents dispatched with `isolation: "worktree"` via the Agent tool), the merge protocol ensures that integrating work from different agents does not break validation gates.
+When working with agent teams (multiple agents dispatched via the Agent tool), the merge protocol ensures that integrating work from different agents does not break validation gates.
 
 ### The Protocol
 
@@ -313,7 +313,7 @@ Merging all agent branches simultaneously and then running tests makes it imposs
 1. **Merge one agent branch at a time** — never batch-merge
 2. **Run Gates 1-3 after each merge** — build, unit tests, integration tests
 3. **Run Gate 5 after all merges** — launch verification on the fully integrated codebase
-4. **Clean up after each merge**: remove the worktree (`git worktree remove <path>`), then delete the branch (`git branch -D <branch>`). Claude Code only auto-cleans worktrees when agents make no changes; when changes are committed, the caller must remove the worktree before deleting the branch.
+4. **Clean up after each merge**: delete the merged branch (`git branch -D <branch>`).
 5. **If a merge fails validation,** fix it before proceeding to the next merge
 
 ---


### PR DESCRIPTION
Agent dispatch guidance no longer prescribes worktree isolation; skills
now simply reference dispatching via the Agent tool.

https://claude.ai/code/session_01M8zgoAASFPmfYSBb1x3pQ7