### PR TITLE
Add Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "cavekit",
+  "interface": {
+    "displayName": "Cavekit"
+  },
+  "plugins": [
+    {
+      "name": "ck",
+      "source": {
+        "source": "local",
+        "path": "./plugins/ck"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.github/workflows/sync-codex-plugin.yml
+++ b/.github/workflows/sync-codex-plugin.yml
@@ -1,0 +1,39 @@
+name: Sync Codex plugin
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - FORMAT.md
+      - skills/**/SKILL.md
+      - scripts/sync-codex-plugin.py
+
+concurrency:
+  group: sync-codex-plugin
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Pull latest before making changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin main
+
+      - name: Sync Codex plugin copies
+        run: python3 scripts/sync-codex-plugin.py
+
+      - name: Commit and push if changed
+        run: |
+          git add plugins/ck/skills plugins/ck/FORMAT.md
+          git diff --staged --quiet && exit 0
+          git commit -m "chore: sync Codex plugin copies [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">cavekit</h1>
 
 <p align="center">
-  <strong>compressed spec-driven development for claude code</strong><br/>
+  <strong>compressed spec-driven development for claude code and codex</strong><br/>
   <sub>one file · three commands · zero sub-agents</sub>
 </p>
 
@@ -34,10 +34,12 @@ That's the whole pitch.
 
 ## install
 
+### Claude Code
+
 One line, via the `skills` CLI:
 
 ```bash
-npx skills add JuliusBrussee/cavekit
+npx skills add ryanshepps/cavekit
 ```
 
 Installs five skills into `~/.claude/skills/`: `spec`, `build`, `check`
@@ -50,15 +52,40 @@ Or via the Claude Code marketplace (also adds `/ck:spec`, `/ck:build`,
 `/ck:check` slash commands):
 
 ```bash
-/plugin marketplace add juliusbrussee/cavekit
+/plugin marketplace add ryanshepps/cavekit
 /plugin install ck@cavekit
 ```
 
 Or clone directly:
 
 ```bash
-git clone https://github.com/juliusbrussee/cavekit.git ~/.claude/plugins/cavekit
+git clone https://github.com/ryanshepps/cavekit.git ~/.claude/plugins/cavekit
 ```
+
+The Claude Code interface stays the same: `/ck:spec`, `/ck:build`,
+`/ck:check`.
+
+### Codex
+
+This fork also ships a Codex plugin package at `plugins/ck/` and marketplace
+metadata at `.agents/plugins/marketplace.json`, following the same dual-plugin
+layout as `JuliusBrussee/caveman`.
+
+Add the repository as a Codex plugin marketplace source:
+
+```bash
+github:ryanshepps/cavekit
+```
+
+The Codex plugin exposes the same workflows as skills:
+
+| prompt | workflow |
+|---|---|
+| `/ck:spec` or `use Cavekit spec` | create / amend / backprop `SPEC.md` |
+| `/ck:build` or `use Cavekit build` | implement against `SPEC.md` |
+| `/ck:check` or `use Cavekit check` | read-only drift report |
+| `use Cavekit caveman` | compact Cavekit spec encoding |
+| `use Cavekit backprop` | bug → spec protocol |
 
 ## format
 
@@ -75,6 +102,10 @@ skills/build          plan-execute skill (mirrors commands/build.md)
 skills/check          drift report skill (mirrors commands/check.md)
 skills/caveman        encoding utility
 skills/backprop       bug → spec protocol (six steps)
+plugins/ck            Codex plugin package (synced from root sources)
+.agents/plugins       Codex marketplace metadata
+scripts/              sync helper for Codex plugin copies
+tests/                local repo verification
 ```
 
 ## non-goals

--- a/plugins/ck/.codex-plugin/plugin.json
+++ b/plugins/ck/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "ck",
+  "version": "4.0.0",
+  "description": "Cavekit 4 — compressed spec-driven development for Codex. Three workflows over one SPEC.md file: spec, build, and check.",
+  "author": {
+    "name": "Julius Brussee",
+    "url": "https://github.com/JuliusBrussee"
+  },
+  "homepage": "https://github.com/ryanshepps/cavekit",
+  "repository": "https://github.com/ryanshepps/cavekit",
+  "license": "MIT",
+  "keywords": [
+    "spec-driven",
+    "caveman",
+    "cavekit",
+    "backprop",
+    "sdd"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cavekit",
+    "shortDescription": "Compressed spec-driven development for Codex.",
+    "longDescription": "Cavekit 4 keeps work anchored in one durable SPEC.md file. Use spec to create or amend the spec, build to execute tasks against it, and check to report drift. Caveman encoding keeps spec context compact; backprop records bugs as reusable invariants.",
+    "developerName": "Julius Brussee",
+    "category": "Coding",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/ryanshepps/cavekit",
+    "privacyPolicyURL": "https://github.com/ryanshepps/cavekit/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/ryanshepps/cavekit/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Use Cavekit spec to write a SPEC.md for this idea.",
+      "Use Cavekit build to implement the next SPEC.md task.",
+      "Use Cavekit check to audit drift between SPEC.md and the code."
+    ],
+    "brandColor": "#6B7280",
+    "screenshots": []
+  }
+}

--- a/plugins/ck/FORMAT.md
+++ b/plugins/ck/FORMAT.md
@@ -1,0 +1,119 @@
+# SPEC.md FORMAT
+
+Single file. Project root. Every cavekit command reads it.
+
+## SECTIONS
+
+Fixed order. Fixed headers. Addressable.
+
+```
+# SPEC
+
+## §G GOAL
+one line. what code must do.
+
+## §C CONSTRAINTS
+- bullet. non-negotiable boundary.
+- bullet. tech/lang/lib locked in.
+
+## §I INTERFACES
+external surface. what world sees.
+- cmd: `foo bar` → stdout JSON
+- api: POST /x → 200 {id}
+- file: `config.yaml` schema …
+- env: `FOO_KEY` required
+
+## §V INVARIANTS
+numbered. testable. each ! MUST hold.
+V1: ∀ req → auth check before handler
+V2: token expiry ≤ ⊥ allowed
+V3: DB write ! in transaction
+
+## §T TASKS
+pipe table. ids monotonic (never reused). status: `x` done / `~` wip / `.` todo.
+id|status|task|cites
+T1|.|scaffold repo|-
+T2|.|impl §I.api POST /x|V2
+T3|x|add §V.1 middleware|V1,I.api
+
+## §B BUGS
+pipe table. backprop log. each row = bug + invariant that catches recurrence.
+id|date|cause|fix
+B1|2026-04-20|token `<` not `≤`|V2
+B2|2026-04-21|race on write|V3
+```
+
+**Table cell rules**: literal `|` → escape as `\|`. Backticks OK. Cells trimmed. Empty = `-`.
+
+## ADDRESSING
+
+`§<S>.<n>` = section.item. `§V.2` = invariants section, item 2.
+Commands, commits, PRs all reference by §. Zero ambiguity.
+
+## CAVEMAN ENCODING
+
+Default for every section. Rules:
+
+- Drop articles (a, an, the). Drop filler.
+- Drop aux verbs (is, are, was) where fragment works.
+- Short synonyms (fix > implement).
+- Fragments fine.
+
+**Preserve verbatim**: code, paths, identifiers, URLs, numbers, error strings, SQL, regex.
+
+**Symbols** (save tokens, machine-readable):
+
+```
+→   leads to / becomes / triggers
+∴   therefore / fix
+∀   for all / every
+∃   exists / some
+!   must
+?   may / optional
+⊥   never / impossible / forbidden
+≠   not equal / differs from
+∈   in / member of
+∉   not in
+≤   at most
+≥   at least
+&   and
+|   or
+```
+
+**Bad** (v1 prose):
+
+> The authentication middleware must verify the token expiry on every request before allowing the handler to execute.
+
+**Good** (v2 caveman):
+
+> V1: ∀ req → auth check before handler
+
+**Bad** (prose bug note):
+
+> Fixed a bug where token expiry comparison used strict less-than instead of less-than-or-equal, causing tokens to be rejected exactly at their expiry timestamp.
+
+**Good** (v2 caveman):
+
+> B1: token `<` not `<=` ∴ tokens rejected @ expiry. §V.2 now ! `≤`.
+
+## WHY CAVEMAN FOR SPECS
+
+Spec loaded every invocation. 75% fewer tokens = 75% fewer dollars & faster reads.
+Human skims fast too. Symbols unambiguous.
+
+## ONE FILE RULE
+
+Big project → more sections, not more files. grep ceremony kills agent speed.
+If SPEC.md > 500 lines, compact §B (old bugs drop oldest) before splitting.
+
+## WRITES
+
+| command | writes | section |
+|---|---|---|
+| `/spec new` | creates | all |
+| `/spec amend` | edits | chosen |
+| `/spec bug` | appends | §B + §V |
+| `/build` | flips | §T status cell `.` → `~` → `x` |
+| `/check` | — | read only |
+
+That is whole format.

--- a/plugins/ck/skills/backprop/SKILL.md
+++ b/plugins/ck/skills/backprop/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: backprop
+description: |
+  Bug → spec protocol. When a bug is found or a test fails, trace the cause,
+  decide whether a new §V invariant would catch recurrence, append to §B.
+  This is the one non-obvious thing SDD does that plan-then-execute doesn't.
+  Triggers on test failure, bug report, post-mortem, or explicit user ask.
+  Codex triggers: `use Cavekit backprop`, `backprop`, test failures, bug reports, and prompts that ask to turn a bug into SPEC.md memory.
+---
+
+# backprop — bug → spec
+
+Plan-then-execute fixes the code & forgets.
+SDD fixes the code AND edits spec so recurrence is impossible.
+That edit is backprop.
+
+## WHEN TO BACKPROP
+
+- Test failed at `/build` verification.
+- User reports bug.
+- Post-mortem after production incident.
+- `/check` flags VIOLATE with root cause found.
+
+## SIX STEPS
+
+### 1. TRACE
+Read failure output / bug report.
+Find exact file:line of wrong behavior.
+Name root cause in one caveman sentence.
+
+### 2. ANALYZE
+Ask three questions:
+- Would a new §V invariant catch this class of bug? (most common: yes)
+- Is §I wrong — did spec claim shape the code cannot deliver? (sometimes)
+- Is §T wrong — did we build the wrong thing? (rare but real)
+
+### 3. PROPOSE
+Draft the spec change. Never skip §B; §V/§I/§T are case-by-case.
+
+Template:
+```
+§B row: B<next>|<date>|<root cause>|V<N>
+§V line: V<next>: <testable rule that would have caught it>
+```
+
+Example:
+```
+§B row: B3|2026-04-20|refund job ran twice on retry|V7
+§V line: V7: ∀ refund → idempotency key check before charge reversal
+```
+
+### 4. GENERATE TEST
+New invariant without test = lie. Add failing test first.
+Name test so it cites the invariant: `TestV7_RefundIdempotent`.
+
+### 5. VERIFY
+Fix code. Run test. Must pass. Run full suite. Must not regress.
+
+### 6. LOG
+Commit spec edit + test + code fix together.
+Commit msg: `backprop §B.<n> + §V.<N>: <one-line cause>`.
+
+## WHAT MAKES A GOOD INVARIANT
+
+- Testable in code (grep-able or assert-able).
+- Scoped to a behavior, not a file.
+- Stated positively when possible (`! hold` over `⊥ forbid`).
+- References §I surface where it applies.
+
+**Bad**: V8: code should be correct.
+**Good**: V8: ∀ pg_query ! params interpolated via driver, ⊥ string concat.
+
+## WHEN NOT TO ADD §V
+
+- Bug was purely mechanical typo with no class (`i++` vs `i--` in throwaway).
+- Fix is a one-time migration.
+- Root cause is external dep (upgrade deps instead, note in §C).
+
+Still append §B entry — record that this failure mode was considered. Future bug with same smell → §B search shows precedent.
+
+## OUTPUT SHAPE
+
+Every backprop run produces:
+1. §B entry (always).
+2. §V entry (usually).
+3. Test file (when §V added).
+4. Code fix.
+5. One commit.
+
+No dashboards. No log files. SPEC.md + git is the full history.

--- a/plugins/ck/skills/build/SKILL.md
+++ b/plugins/ck/skills/build/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: build
+description: |
+  Plan-then-execute implementation against SPEC.md. Native single-thread
+  loop, no sub-agents. On test or build failure, auto-invokes the backprop
+  skill before retrying — a failed verification always considers whether
+  a new §V invariant would prevent recurrence. Triggers when the user asks
+  to build, implement, execute the spec, or tackle a specific §T task
+  (`build §T.3`, `build --next`, `implement next task`, `run the build`).
+  Expects SPEC.md to exist; if not, defers to the spec skill.
+  Codex triggers: `/ck:build`, `ck build`, `use Cavekit build`, and prompts that ask to implement, execute, or build against SPEC.md.
+---
+
+# build — implement spec
+
+Single-thread native plan→execute. You are main Claude. No swarm.
+
+## LOAD
+
+1. Read `SPEC.md`. If missing → tell user to invoke the spec skill first. Stop.
+2. Read `FORMAT.md` once if not loaded.
+3. Parse invocation args:
+   - `§T.n` → that task only
+   - `--next` → lowest-numbered row with status `.` or `~`
+   - `--all` or empty → every `.` row in §T order
+
+## PLAN
+
+Native plan mode. For chosen task(s):
+
+1. Cite every §V invariant that applies. Plan must respect all.
+2. Cite every §I interface touched. Plan must preserve shape.
+3. List files to create / edit.
+4. List tests to add or update (one per invariant touched).
+5. Name verification command (test, build, lint).
+
+Show plan. Wait for user OK unless auto mode.
+
+## EXECUTE
+
+Per task in order:
+
+1. Flip §T.n status cell `.` → `~`. Just write to SPEC.md.
+2. Edit code per plan.
+3. Run verification command.
+4. **Pass** → flip `~` → `x`. Next task.
+5. **Fail** → invoke backprop skill. Do NOT retry blindly.
+
+## FAIL → BACKPROP
+
+On test/build failure:
+
+1. Read failure output.
+2. Ask: is failure (a) my code bug, (b) spec wrong, or (c) unspecified edge case?
+3. If (a) → fix code, re-run. No spec change.
+4. If (b) or (c) → invoke spec skill with `bug: <cause>` first, let it update §V and §B, then resume build against updated spec.
+
+Rule: never silently fix root-cause without considering backprop. §B is the memory that stops recurrence.
+
+## WRITE POLICY
+
+- Only flip §T status. No other SPEC.md edits from build.
+- Other spec edits → invoke spec skill.
+- Commit after each §T completes. Message: `T<n>: <goal line>` + §V cites.
+
+## VERIFICATION
+
+Task `x` only if:
+- Verification command exits 0.
+- New test(s) added per plan.
+- No §V invariant regressed (run full test suite at end).
+
+## NON-GOALS
+
+- No sub-agents. No parallel workers. Main thread only.
+- No progress dashboards. `cat SPEC.md | grep §T` is the dashboard.
+- No speculative work beyond chosen task scope.

--- a/plugins/ck/skills/caveman/SKILL.md
+++ b/plugins/ck/skills/caveman/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: caveman
+description: |
+  Caveman encoding for SPEC.md and spec-adjacent writes. Loaded by /spec, /build,
+  /check. Cuts tokens ~75% vs prose while staying precise. Triggers on any write
+  to SPEC.md or when user says "caveman", "compress this", "be brief".
+  Codex triggers: `use Cavekit caveman`, `caveman`, `compress this`, and spec-adjacent writes that need compact Cavekit encoding.
+---
+
+# caveman — spec encoding
+
+Applies to SPEC.md writes, spec-referencing prose, backprop entries.
+Does NOT apply to code, error strings, commit messages, PR descriptions.
+
+## GRAMMAR
+
+- Drop articles (a, an, the).
+- Drop filler (just, really, basically, simply, actually).
+- Drop aux verbs where fragment works (is, are, was, were, being).
+- Drop pleasantries.
+- No hedging (skip "might", "perhaps", "could be worth").
+- Fragments fine.
+- Short synonyms: fix > implement, big > extensive, run > execute.
+
+## SYMBOLS
+
+Prefer over words:
+
+```
+→   leads to / becomes / on <x>
+∴   therefore / fix
+∀   for all / every
+∃   exists / some
+!   must / required
+?   may / optional / unknown
+⊥   never / forbidden / nil
+≠   not equal
+∈   in
+∉   not in
+≤   at most
+≥   at least
+&   and
+|   or
+§   section reference
+```
+
+## PRESERVE VERBATIM
+
+Never compress:
+
+- Code blocks, snippets, one-liners with backticks.
+- Paths: `src/auth/mw.go`.
+- URLs.
+- Identifiers: function names, variable names, env vars.
+- Numbers and versions.
+- Error message strings.
+- SQL, regex, JSON, YAML.
+- Quoted strings.
+
+## SHAPES
+
+**Invariant**:
+```
+V<n>: <subject> <relation> <condition>
+V1: ∀ req → auth check before handler
+V2: token expiry ≤ current_time → reject
+```
+
+**Bug row** (pipe table under §B):
+```
+id|date|cause|fix
+B1|2026-04-20|token `<` not `≤`|V2
+```
+
+**Task row** (pipe table under §T):
+```
+id|status|task|cites
+T3|x|add auth mw|V1,I.api
+```
+Status: `x` done, `~` wip, `.` todo. Escape literal `|` as `\|`.
+
+**Interface**:
+```
+<kind>: <name> → <shape>
+api: POST /x → 200 {id:string}
+cmd: `foo bar <arg>` → stdout JSON
+env: FOO_KEY ! set
+```
+
+## EXAMPLES
+
+**Bad**:
+> The system should ensure that every incoming request is properly authenticated before being forwarded to its corresponding handler function.
+
+**Good**:
+> V1: ∀ req → auth check before handler
+
+**Bad**:
+> We discovered that the token expiration check in the middleware was using a strict less-than comparison operator, which meant tokens were being rejected at the exact moment of their expiry.
+
+**Good**:
+> B1: token `<` not `≤` → reject @ expiry boundary.
+
+**Bad**:
+> The POST endpoint at /x accepts a JSON body and returns a 200 response with an object containing the created id.
+
+**Good**:
+> api: POST /x → 200 {id}
+
+## BOUNDARIES
+
+- User asks for prose explanation → switch to normal English.
+- Spec documents for external review (RFC, pitch) → normal English.
+- Commit message → normal English (git readers expect it).
+- Diff comment in code → normal English.
+
+## WHEN UNSURE
+
+If cutting a word loses a fact, keep it. Caveman is compression, not amputation.

--- a/plugins/ck/skills/check/SKILL.md
+++ b/plugins/ck/skills/check/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: check
+description: |
+  Read-only drift detector. Diffs SPEC.md against current code and reports
+  violations grouped by severity. Writes nothing — suggests remedies via
+  the spec or build skills but never invokes them. Triggers when the user
+  asks to check drift, audit the spec, verify invariants, or ask whether
+  code still matches the spec. Phrasings: "check drift", "audit the spec",
+  "does the code still match §V", "check invariants", "spec vs code".
+  Codex triggers: `/ck:check`, `ck check`, `use Cavekit check`, and prompts that ask to audit drift, check invariants, or compare SPEC.md to code.
+---
+
+# check — drift report
+
+Pure diagnostic. Reports violations. Writes nothing. User decides remedy.
+
+## LOAD
+
+1. Read `SPEC.md`. If missing → "no spec, nothing to check." Stop.
+2. Parse invocation args:
+   - `§V` → check invariants only (default)
+   - `§I` → check interfaces
+   - `§T` → audit task status vs code
+   - `--all` → all three
+
+## CHECK §V — invariants
+
+For each V<n>:
+
+1. Translate invariant into verifiable claim about code.
+2. Grep / read relevant files.
+3. Classify: **HOLD** / **VIOLATE** / **UNVERIFIABLE**.
+4. Record address + file:line evidence.
+
+## CHECK §I — interfaces
+
+For each I item:
+
+1. Locate implementation.
+2. Classify:
+   - **MATCH** — shape in code = shape in spec.
+   - **DRIFT** — impl exists, shape differs.
+   - **MISSING** — impl absent.
+   - **EXTRA** — code exposes surface not in §I.
+
+## CHECK §T — tasks
+
+For each T<n>:
+
+1. If `x`: verify claimed work present.
+2. If `~`: note as in-progress.
+3. If `.`: note as pending.
+4. Flag `x` rows with no evidence as **STALE**.
+
+## REPORT
+
+Caveman. Grouped by severity.
+
+```
+## §V drift
+V2 VIOLATE: auth/mw.go:47 uses `<` not `≤`. see §B.1.
+V5 UNVERIFIABLE: no test covers ∀ req path.
+
+## §I drift
+I.api DRIFT: POST /x returns `{result}` not `{id}`. route.go:112.
+I.cmd MISSING: `foo bar` absent from cli/*.go.
+
+## §T drift
+T3 STALE: status `x`, no middleware file exists.
+
+## summary
+2 violate. 1 missing. 1 stale. 1 unverifiable.
+next: spec skill with `bug:` or fix code at cited lines.
+```
+
+## REMEDY HINTS (not actions)
+
+End report with one-line hint per class:
+- VIOLATE / DRIFT → invoke spec skill `bug: <V.n>` or fix code.
+- MISSING → invoke build skill on `§T.n` if task exists; else spec skill `amend §T`.
+- STALE → spec skill `amend §T` to uncheck.
+- EXTRA → spec skill `amend §I` to document, or delete code.
+
+Never invoke fixes. Report only.
+
+## NON-GOALS
+
+- Zero writes. No SPEC.md edits. No code edits.
+- No sub-agents. Main thread reads.
+- No scores, no grades. Binary per item: holds or drifts.

--- a/plugins/ck/skills/spec/SKILL.md
+++ b/plugins/ck/skills/spec/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: spec
+description: |
+  Create, amend, or backprop bugs into SPEC.md at repo root. Sole mutator
+  of the project spec. Triggers when the user asks to write a spec, start
+  a new spec, distill a spec from existing code, add invariants, amend
+  sections (§G, §C, §I, §V, §T, §B), or record a bug via backprop.
+  Codex triggers: `/ck:spec`, `ck spec`, `use Cavekit spec`, and prompts that ask to create, amend, distill, or backprop a SPEC.md.
+  Common phrasings: "write the spec for...", "new spec", "bug: ...",
+  "amend §V.3", "distill spec from code", "spec this idea". Reads and
+  follows FORMAT.md for the caveman encoding rules and pipe-table shape
+  of §T and §B.
+---
+
+# spec — spec mutator
+
+Read `FORMAT.md` at repo root if not already loaded. Caveman skill applies to all writes here.
+
+## DISPATCH
+
+Inspect user request and project state:
+
+1. No `SPEC.md` at repo root AND args describe idea → **NEW**
+2. No `SPEC.md` AND `from-code` in args → **DISTILL**
+3. `SPEC.md` exists AND args start `bug:` → **BACKPROP**
+4. `SPEC.md` exists AND args start `amend` → **AMEND**
+5. `SPEC.md` exists, no args → ask user which mode
+
+## NEW — idea → spec
+
+Input: user idea.
+
+Steps:
+1. Extract goal (1 line, caveman). → §G.
+2. List constraints user stated or implied. → §C.
+3. List external surfaces user named. → §I.
+4. Propose initial invariants. → §V (numbered V1…).
+5. Break goal into ordered tasks. → §T pipe table, all status `.`, ids T1…
+6. §B section with header row only (`id|date|cause|fix`).
+
+Write to `SPEC.md`. Show user full file. Ask: "spec OK? suggest edits or invoke build."
+
+## DISTILL — code → spec
+
+Walk repo. Produce §G (infer from README/package.json/main entry), §C (infer from stack), §I (enumerate public APIs/CLIs/configs), §V (derive from tests and assertions), §T (one task per known TODO or missing test), §B (empty).
+
+Caveman everywhere. Flag uncertain items with `?` in text so user can confirm.
+
+## BACKPROP — bug → §B + §V
+
+Input: `bug: <description>`.
+
+Steps:
+1. Parse bug description.
+2. Find root cause (read relevant code).
+3. Decide: would a new invariant catch recurrence? If yes → draft `V<next>`.
+4. Append §B row: `B<next>|<date>|<cause>|V<N>`.
+5. Append new invariant to §V.
+6. If fix also changes behavior → add/update §T rows.
+7. Show diff. Apply only on user OK.
+
+Rule: every bug gets a §B entry. Invariant optional but preferred.
+
+## AMEND — targeted edit
+
+Input: `amend §V.3` or `amend §T` etc.
+
+Read that section. Show current. Ask user what changes. Write. Show diff.
+
+Never silently rewrite sections user did not name.
+
+## OUTPUT RULES
+
+- Caveman format per `FORMAT.md`.
+- Preserve identifiers, paths, code verbatim.
+- Numbering monotonic — never reuse §V.N or §B.N.
+- §T row `cites` column ! list §V/§I deps: `T5|.|impl auth mw|V2,I.api`.
+
+## NON-GOALS
+
+- No sub-agents. Main thread writes.
+- No dashboards, no logs, no state files beyond SPEC.md itself.
+- No auto-build after spec. User invokes build explicitly.

--- a/scripts/sync-codex-plugin.py
+++ b/scripts/sync-codex-plugin.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Sync Codex plugin assets from the root Cavekit sources."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import shutil
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "plugins" / "ck"
+
+SKILLS = {
+    "spec": [
+        "Codex triggers: `/ck:spec`, `ck spec`, `use Cavekit spec`, and prompts that ask to create, amend, distill, or backprop a SPEC.md.",
+    ],
+    "build": [
+        "Codex triggers: `/ck:build`, `ck build`, `use Cavekit build`, and prompts that ask to implement, execute, or build against SPEC.md.",
+    ],
+    "check": [
+        "Codex triggers: `/ck:check`, `ck check`, `use Cavekit check`, and prompts that ask to audit drift, check invariants, or compare SPEC.md to code.",
+    ],
+    "caveman": [
+        "Codex triggers: `use Cavekit caveman`, `caveman`, `compress this`, and spec-adjacent writes that need compact Cavekit encoding.",
+    ],
+    "backprop": [
+        "Codex triggers: `use Cavekit backprop`, `backprop`, test failures, bug reports, and prompts that ask to turn a bug into SPEC.md memory.",
+    ],
+}
+
+
+def add_codex_triggers(text: str, skill: str) -> str:
+    insert = "\n".join(f"  {line}" for line in SKILLS[skill])
+    marker = "  Common phrasings:"
+
+    if f"Codex triggers:" in text:
+        return text
+
+    if marker in text:
+        return text.replace(marker, f"{insert}\n{marker}", 1)
+
+    needle = "---\n\n# "
+    if needle not in text:
+        raise ValueError(f"{skill}: could not find frontmatter boundary")
+    return text.replace(needle, f"{insert}\n---\n\n# ", 1)
+
+
+def expected_files() -> dict[Path, str]:
+    files: dict[Path, str] = {
+        PLUGIN / "FORMAT.md": (ROOT / "FORMAT.md").read_text(),
+    }
+
+    for skill in sorted(SKILLS):
+        source = ROOT / "skills" / skill / "SKILL.md"
+        files[PLUGIN / "skills" / skill / "SKILL.md"] = add_codex_triggers(
+            source.read_text(),
+            skill,
+        )
+
+    return files
+
+
+def diff_text(path: Path, expected: str) -> str:
+    actual = path.read_text() if path.exists() else ""
+    return "".join(
+        difflib.unified_diff(
+            actual.splitlines(keepends=True),
+            expected.splitlines(keepends=True),
+            fromfile=str(path),
+            tofile=f"{path} (expected)",
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if generated Codex plugin assets are out of sync",
+    )
+    args = parser.parse_args()
+
+    expected = expected_files()
+    stale = [(path, content) for path, content in expected.items() if not path.exists() or path.read_text() != content]
+
+    if args.check:
+        if not stale:
+            return 0
+        for path, content in stale:
+            sys.stderr.write(diff_text(path, content))
+        return 1
+
+    for path, content in expected.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    # Remove copied skill folders that no longer exist at the root.
+    skills_dir = PLUGIN / "skills"
+    if skills_dir.exists():
+        for child in skills_dir.iterdir():
+            if child.is_dir() and child.name not in SKILLS:
+                shutil.rmtree(child)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Local verification runner for Cavekit install surfaces."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CheckFailure(RuntimeError):
+    pass
+
+
+def section(title: str) -> None:
+    print(f"\n== {title} ==")
+
+
+def ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise CheckFailure(message)
+
+
+def run(args: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise CheckFailure(
+            f"Command failed ({result.returncode}): {' '.join(args)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
+
+
+def read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_synced_files() -> None:
+    section("Synced Files")
+
+    result = run([sys.executable, "scripts/sync-codex-plugin.py", "--check"], check=False)
+    if result.returncode != 0:
+        raise CheckFailure(
+            "Codex plugin mirror is out of sync\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+    for skill in ["backprop", "build", "caveman", "check", "spec"]:
+        ensure(
+            (ROOT / "plugins" / "ck" / "skills" / skill / "SKILL.md").exists(),
+            f"Codex plugin skill copy missing: {skill}",
+        )
+
+    ensure(
+        (ROOT / "plugins/ck/FORMAT.md").exists(),
+        "Codex plugin FORMAT.md copy missing",
+    )
+
+    print("Codex skill and FORMAT.md mirrors OK")
+
+
+def verify_manifests() -> None:
+    section("Manifests")
+
+    claude_plugin = read_json(ROOT / ".claude-plugin/plugin.json")
+    claude_marketplace = read_json(ROOT / ".claude-plugin/marketplace.json")
+    codex_plugin = read_json(ROOT / "plugins/ck/.codex-plugin/plugin.json")
+    codex_marketplace = read_json(ROOT / ".agents/plugins/marketplace.json")
+
+    ensure(isinstance(claude_plugin, dict), "Claude plugin manifest must be an object")
+    ensure(isinstance(claude_marketplace, dict), "Claude marketplace manifest must be an object")
+    ensure(isinstance(codex_plugin, dict), "Codex plugin manifest must be an object")
+    ensure(isinstance(codex_marketplace, dict), "Codex marketplace manifest must be an object")
+
+    ensure(claude_plugin["name"] == "ck", "Claude plugin name must remain ck")
+    ensure(codex_plugin["name"] == "ck", "Codex plugin name must be ck")
+    ensure(codex_plugin["skills"] == "./skills/", "Codex plugin skills path must be ./skills/")
+
+    ensure(codex_marketplace["name"] == "cavekit", "Codex marketplace name must be cavekit")
+    ensure(
+        codex_marketplace["interface"]["displayName"] == "Cavekit",
+        "Codex marketplace display name must be Cavekit",
+    )
+
+    plugins = codex_marketplace["plugins"]
+    ensure(len(plugins) == 1, "Codex marketplace must expose exactly one plugin")
+    plugin = plugins[0]
+    ensure(plugin["name"] == "ck", "Codex marketplace plugin name must be ck")
+    ensure(
+        plugin["source"] == {"source": "local", "path": "./plugins/ck"},
+        "Codex marketplace source must point to ./plugins/ck",
+    )
+    ensure(
+        plugin["policy"] == {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+        "Codex marketplace policy must be AVAILABLE/ON_INSTALL",
+    )
+    ensure(plugin["category"] == "Coding", "Codex marketplace category must be Coding")
+
+    print("Claude and Codex manifests OK")
+
+
+def verify_codex_trigger_text() -> None:
+    section("Codex Trigger Text")
+
+    expected = {
+        "spec": "/ck:spec",
+        "build": "/ck:build",
+        "check": "/ck:check",
+    }
+    for skill, trigger in expected.items():
+        text = (ROOT / "plugins" / "ck" / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
+        ensure("Codex triggers:" in text, f"{skill} skill missing Codex trigger line")
+        ensure(trigger in text, f"{skill} skill missing {trigger} trigger")
+        ensure(f"use Cavekit {skill}" in text, f"{skill} skill missing natural-language Cavekit trigger")
+
+    print("Codex slash and natural-language triggers OK")
+
+
+def main() -> int:
+    checks = [
+        verify_synced_files,
+        verify_manifests,
+        verify_codex_trigger_text,
+    ]
+
+    try:
+        for check in checks:
+            check()
+    except CheckFailure as exc:
+        print(f"\nFAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print("\nAll local verification checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Codex marketplace metadata for Cavekit at .agents/plugins/marketplace.json
- add plugins/ck with .codex-plugin manifest and synced Cavekit skills
- add sync and verification scripts modeled after the Caveman repo
- document Claude Code and Codex install paths

## Validation
- python3 scripts/sync-codex-plugin.py --check
- python3 tests/verify_repo.py