### PR TITLE
feat: archive

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -110,7 +110,7 @@ If SPEC.md > 500 lines, invoke `/archive`. Never split into multiple specs.
 
 When SPEC.md > 500 lines, `/archive` skill handles it:
 
-1. Copy **full** SPEC.md → `.cavekit/archive/SPEC-<date>.md`
+1. Copy **full** SPEC.md → `.cavekit/archive/SPEC-<date>.md`. If `SPEC-<date>.md` already exists → append `-2`, `-3`, etc.
 2. In working SPEC.md:
    - §T: remove rows with status `x`. Add comment above table: `<!-- archive: .cavekit/archive/SPEC-<date>.md §T T1-T12 -->`
    - §B: remove rows older than 90 days. Add comment above table: `<!-- archive: .cavekit/archive/SPEC-<date>.md §B B1-B5 -->`
@@ -133,7 +133,7 @@ Archive comments carry the range for ID lookup. New tasks may cite archived V/N 
 | `/spec new` | creates | all |
 | `/spec amend` | edits | chosen |
 | `/spec bug` | appends | §B + §V |
-| `/archive` | archives + trims | §T done, §B old |
+| `/archive` | archives + trims | §T done, §B old, §V/§I/§C unreferenced |
 | `/build` | flips | §T status cell `.` → `~` → `x` |
 | `/check` | — | read only |
 

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -104,7 +104,27 @@ Human skims fast too. Symbols unambiguous.
 ## ONE FILE RULE
 
 Big project → more sections, not more files. grep ceremony kills agent speed.
-If SPEC.md > 500 lines, compact §B (old bugs drop oldest) before splitting.
+If SPEC.md > 500 lines, invoke `/archive`. Never split into multiple specs.
+
+## ARCHIVE
+
+When SPEC.md > 500 lines, `/archive` skill handles it:
+
+1. Copy **full** SPEC.md → `.cavekit/archive/SPEC-<date>.md`
+2. In working SPEC.md:
+   - §T: remove rows with status `x`. Add comment above table: `<!-- archive: .cavekit/archive/SPEC-<date>.md §T T1-T12 -->`
+   - §B: remove rows older than 90 days. Add comment above table: `<!-- archive: .cavekit/archive/SPEC-<date>.md §B B1-B5 -->`
+   - §V: remove invariants NOT cited by any active §T (status `.` or `~`). Add comment: `<!-- archive: ... §V V1,V3-V5 -->`
+   - §I: remove interfaces NOT cited by any active §T. Add comment: `<!-- archive: ... §I I.cli -->`
+   - §C: remove constraints NOT cited by any active §T. Add comment: `<!-- archive: ... §C -->`
+   - §G: never touched
+3. Show diff. Apply only on user OK.
+
+Archive dir: `.cavekit/archive/`. One file per run. Full copy = nothing lost.
+`check` and `build` read archive when needed.
+
+After archive, new IDs continue from max(current + archived). Never reuse.
+Archive comments carry the range for ID lookup. New tasks may cite archived V/N or I/X.
 
 ## WRITES
 
@@ -113,6 +133,7 @@ If SPEC.md > 500 lines, compact §B (old bugs drop oldest) before splitting.
 | `/spec new` | creates | all |
 | `/spec amend` | edits | chosen |
 | `/spec bug` | appends | §B + §V |
+| `/archive` | archives + trims | §T done, §B old |
 | `/build` | flips | §T status cell `.` → `~` → `x` |
 | `/check` | — | read only |
 

--- a/commands/archive.md
+++ b/commands/archive.md
@@ -18,15 +18,17 @@ When SPEC.md > 500 lines. Full copy to archive. Trim working copy.
 Analyze SPEC.md. Identify what would be archived. Show preview. No files touched.
 
 Steps:
+
 1. Count total lines → `lines before`.
 2. §T: count rows with status `x`. List their IDs. Count their lines.
-3. §B: count rows with date > 90 days old. List their IDs. Count their lines.
+3. §B: count rows whose date is older than the 90-day cutoff (date < today − 90 days). List their IDs. Count their lines.
 4. §V: collect `cites` from active §T (`.` or `~`). Find V<n> not in live set. List them. Count their lines.
 5. §I: same logic as §V. List unreferenced I items. Count their lines.
 6. §C: same logic. Count their lines.
 7. `lines after` = `lines before` - (§T lines + §B lines + §V lines + §I lines + §C lines) + (archive comment lines: 1 per trimmed section). Exact count.
 
 Show preview:
+
 ```
 ## archive preview
 
@@ -70,7 +72,7 @@ In working SPEC.md only. Archive untouched.
 
 ### §B — old bugs
 
-1. Find all rows where date column > 90 days old.
+1. Find all rows where age ≥ 90 days (date < today-90d).
 2. Record id range (e.g. `B1-B5`).
 3. Remove those rows from table.
 4. Insert HTML comment above §B table header:
@@ -128,7 +130,8 @@ saved to: .cavekit/archive/SPEC-2026-05-15.md
 §B archived: B1-B4 (4 bugs older than 90 days)
 §V archived: V1,V3-V5 (4 invariants, no active task cites them)
 §I archived: I.cli (1 interface, no active task cites it)
-§G §C untouched
+§C archived: 2 constraints, no active task cites them
+§G untouched
 
 lines before: 542
 lines after: 218

--- a/commands/archive.md
+++ b/commands/archive.md
@@ -1,0 +1,148 @@
+---
+description: Archive old SPEC.md content when file exceeds 500 lines. Full copy + trim.
+argument-hint: (no args needed)
+---
+
+# /archive — compact SPEC.md
+
+When SPEC.md > 500 lines. Full copy to archive. Trim working copy.
+
+## PRECHECK
+
+1. Read `SPEC.md`. If missing → "no spec, nothing to archive." Stop.
+2. Count lines. If < 500 → "SPEC.md is <N> lines. Nothing to archive." Stop.
+3. Read `FORMAT.md` if not loaded.
+
+## RESEARCH — dry-run (no writes)
+
+Analyze SPEC.md. Identify what would be archived. Show preview. No files touched.
+
+Steps:
+1. Count total lines → `lines before`.
+2. §T: count rows with status `x`. List their IDs. Count their lines.
+3. §B: count rows with date > 90 days old. List their IDs. Count their lines.
+4. §V: collect `cites` from active §T (`.` or `~`). Find V<n> not in live set. List them. Count their lines.
+5. §I: same logic as §V. List unreferenced I items. Count their lines.
+6. §C: same logic. Count their lines.
+7. `lines after` = `lines before` - (§T lines + §B lines + §V lines + §I lines + §C lines) + (archive comment lines: 1 per trimmed section). Exact count.
+
+Show preview:
+```
+## archive preview
+
+§T would archive: T1, T3-T8, T12 (9 tasks completed)
+§B would archive: B1-B4 (4 bugs older than 90 days)
+§V would archive: V1,V3-V5 (4 invariants, no active task cites them)
+§I would archive: I.cli (1 interface, no active task cites it)
+§C would archive: 2 constraints, no active task cites them
+§G untouched
+
+lines before: 533
+lines after: 100
+
+Proceed? (yes / no / amend)
+```
+
+If user says **yes** → continue to ARCHIVE + TRIM.
+If user says **no** → stop. Nothing written.
+If user says **amend** → user specifies what to exclude/include, re-run RESEARCH.
+
+## ARCHIVE
+
+1. Create `.cavekit/archive/` dir if absent.
+2. Copy **full** SPEC.md → `.cavekit/archive/SPEC-<YYYY-MM-DD>.md`. Exact copy, no changes.
+3. If `.cavekit/archive/SPEC-<today>.md` already exists → append `-2`, `-3`, etc.
+
+## TRIM
+
+In working SPEC.md only. Archive untouched.
+
+### §T — completed tasks
+
+1. Find all rows with status `x`.
+2. Record id range (e.g. `T1-T12`).
+3. Remove those rows from table.
+4. Insert HTML comment above §T table header:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §T T1-T12 -->
+```
+
+### §B — old bugs
+
+1. Find all rows where date column > 90 days old.
+2. Record id range (e.g. `B1-B5`).
+3. Remove those rows from table.
+4. Insert HTML comment above §B table header:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §B B1-B5 -->
+```
+
+### §V — unreferenced invariants
+
+1. Collect all `cites` values from **active** §T rows (status `.` or `~`). Extract every V<n> reference.
+2. This is the **live set** — invariants still actively enforced by pending work.
+3. For each V<n> NOT in live set → candidate for archive.
+4. Remove those invariant lines from §V.
+5. Insert HTML comment above §V section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §V V1,V3-V5 -->
+```
+
+### §I — unreferenced interfaces
+
+1. Same logic as §V: collect all `I.*` references from active §T rows.
+2. For each I item NOT in live set → candidate for archive.
+3. Remove those interface lines from §I.
+4. Insert HTML comment above §I section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §I I.api,I.cli -->
+```
+
+### §C — unreferenced constraints
+
+1. Same logic as §V: collect all §C references from active §T rows.
+2. For each §C item NOT in live set → candidate for archive.
+3. Remove those constraint lines from §C.
+4. Insert HTML comment above §C section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §C -->
+```
+
+### §G — never touched. Project identity.
+
+## REPORT
+
+Show diff of SPEC.md (before → after). Format:
+
+```
+## archive report
+
+saved to: .cavekit/archive/SPEC-2026-05-15.md
+
+§T archived: T1, T3-T8, T12 (9 tasks completed)
+§B archived: B1-B4 (4 bugs older than 90 days)
+§V archived: V1,V3-V5 (4 invariants, no active task cites them)
+§I archived: I.cli (1 interface, no active task cites it)
+§G §C untouched
+
+lines before: 542
+lines after: 218
+```
+
+Apply only on user OK.
+
+## RULES
+
+- Archive = full copy. Nothing lost. Ever.
+- `check` and `build` read `.cavekit/archive/` when they need historical context.
+- One archive file per run. Multiple runs = multiple files. Oldest = furthest history.
+- §G is sacred. Never remove.
+- §C, §V and §I archived only when no active §T (`.` or `~`) cites them.
+- After archive, spec and build skills parse archive comments for max ID.
+  New tasks continue T13+ if T1-T12 archived. Never reuse IDs.
+- New tasks may cite archived V/N or I/X — archive comment points to full text.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -65,9 +65,9 @@ Never silently rewrite sections user did not name.
 - Caveman format per `FORMAT.md`.
 - Preserve identifiers, paths, code verbatim.
 - Numbering monotonic — never reuse §V.N, §B.N, or §T.N.
-- Next ID = max(current table IDs + archive comment ranges) + 1.
-  Parse `<!-- archive: ... §T T1-T12 -->` to find archived ranges.
-  Never start from T1/B1 if archive comments exist.
+- Next IDs computed per section: nextT = 1 + max(current T ids, archived §T ids); nextB = 1 + max(current B ids, archived §B ids); nextV = 1 + max(current V ids, archived §V ids).
+  Parse archive comments like `<!-- archive: ... §T T1-T12 -->`, `<!-- archive: ... §B B1-B5 -->`, `<!-- archive: ... §V V1,V3-V5 -->` (comma lists + `Xn-Xm` ranges).
+  Never restart from T1/B1/V1 if any archive comment exists for that section.
 - §T row `cites` column ! list §V/§I deps: `T5|.|impl auth mw|V2,I.api`.
 
 ## NON-GOALS

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -64,7 +64,10 @@ Never silently rewrite sections user did not name.
 
 - Caveman format per `FORMAT.md`.
 - Preserve identifiers, paths, code verbatim.
-- Numbering monotonic — never reuse §V.N or §B.N.
+- Numbering monotonic — never reuse §V.N, §B.N, or §T.N.
+- Next ID = max(current table IDs + archive comment ranges) + 1.
+  Parse `<!-- archive: ... §T T1-T12 -->` to find archived ranges.
+  Never start from T1/B1 if archive comments exist.
 - §T row `cites` column ! list §V/§I deps: `T5|.|impl auth mw|V2,I.api`.
 
 ## NON-GOALS

--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -22,15 +22,17 @@ When SPEC.md > 500 lines. Full copy to archive. Trim working copy.
 Analyze SPEC.md. Identify what would be archived. Show preview. No files touched.
 
 Steps:
+
 1. Count total lines → `lines before`.
 2. §T: count rows with status `x`. List their IDs. Count their lines.
-3. §B: count rows with date > 90 days old. List their IDs. Count their lines.
+3. §B: count rows with age ≥ 90 days (date < today-90d). List their IDs. Count their lines.
 4. §V: collect `cites` from active §T (`.` or `~`). Find V<n> not in live set. List them. Count their lines.
 5. §I: same logic as §V. List unreferenced I items. Count their lines.
 6. §C: same logic. Count their lines.
 7. `lines after` = `lines before` - (§T lines + §B lines + §V lines + §I lines + §C lines) + (archive comment lines: 1 per trimmed section). Exact count.
 
 Show preview:
+
 ```
 ## archive preview
 
@@ -74,7 +76,7 @@ In working SPEC.md only. Archive untouched.
 
 ### §B — old bugs
 
-1. Find all rows where date column > 90 days old.
+1. Find all rows where age ≥ 90 days (date < today-90d).
 2. Record id range (e.g. `B1-B5`).
 3. Remove those rows from table.
 4. Insert HTML comment above §B table header:
@@ -132,7 +134,8 @@ saved to: .cavekit/archive/SPEC-2026-05-15.md
 §B archived: B1-B4 (4 bugs older than 90 days)
 §V archived: V1,V3-V5 (4 invariants, no active task cites them)
 §I archived: I.cli (1 interface, no active task cites it)
-§G §C untouched
+§C archived: 2 constraints, no active task cites them
+§G untouched
 
 lines before: 542
 lines after: 218

--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: archive
+description: |
+  Archive old SPEC.md content when file exceeds 500 lines. Copies full SPEC.md
+  to .cavekit/archive/ then trims completed tasks, old bugs, and unreferenced
+  invariants/interfaces. Nothing lost — archive is exact copy. Triggers when
+  user says "archive spec", "trim spec", "spec too long", or invokes /archive.
+---
+
+# archive — compact SPEC.md
+
+When SPEC.md > 500 lines. Full copy to archive. Trim working copy.
+
+## PRECHECK
+
+1. Read `SPEC.md`. If missing → "no spec, nothing to archive." Stop.
+2. Count lines. If < 500 → "SPEC.md is <N> lines. Nothing to archive." Stop.
+3. Read `FORMAT.md` if not loaded.
+
+## RESEARCH — dry-run (no writes)
+
+Analyze SPEC.md. Identify what would be archived. Show preview. No files touched.
+
+Steps:
+1. Count total lines → `lines before`.
+2. §T: count rows with status `x`. List their IDs. Count their lines.
+3. §B: count rows with date > 90 days old. List their IDs. Count their lines.
+4. §V: collect `cites` from active §T (`.` or `~`). Find V<n> not in live set. List them. Count their lines.
+5. §I: same logic as §V. List unreferenced I items. Count their lines.
+6. §C: same logic. Count their lines.
+7. `lines after` = `lines before` - (§T lines + §B lines + §V lines + §I lines + §C lines) + (archive comment lines: 1 per trimmed section). Exact count.
+
+Show preview:
+```
+## archive preview
+
+§T would archive: T1, T3-T8, T12 (9 tasks completed)
+§B would archive: B1-B4 (4 bugs older than 90 days)
+§V would archive: V1,V3-V5 (4 invariants, no active task cites them)
+§I would archive: I.cli (1 interface, no active task cites it)
+§C would archive: 2 constraints, no active task cites them
+§G untouched
+
+lines before: 533
+lines after: 100
+
+Proceed? (yes / no / amend)
+```
+
+If user says **yes** → continue to ARCHIVE + TRIM.
+If user says **no** → stop. Nothing written.
+If user says **amend** → user specifies what to exclude/include, re-run RESEARCH.
+
+## ARCHIVE
+
+1. Create `.cavekit/archive/` dir if absent.
+2. Copy **full** SPEC.md → `.cavekit/archive/SPEC-<YYYY-MM-DD>.md`. Exact copy, no changes.
+3. If `.cavekit/archive/SPEC-<today>.md` already exists → append `-2`, `-3`, etc.
+
+## TRIM
+
+In working SPEC.md only. Archive untouched.
+
+### §T — completed tasks
+
+1. Find all rows with status `x`.
+2. Record id range (e.g. `T1-T12`).
+3. Remove those rows from table.
+4. Insert HTML comment above §T table header:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §T T1-T12 -->
+```
+
+### §B — old bugs
+
+1. Find all rows where date column > 90 days old.
+2. Record id range (e.g. `B1-B5`).
+3. Remove those rows from table.
+4. Insert HTML comment above §B table header:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §B B1-B5 -->
+```
+
+### §V — unreferenced invariants
+
+1. Collect all `cites` values from **active** §T rows (status `.` or `~`). Extract every V<n> reference.
+2. This is the **live set** — invariants still actively enforced by pending work.
+3. For each V<n> NOT in live set → candidate for archive.
+4. Remove those invariant lines from §V.
+5. Insert HTML comment above §V section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §V V1,V3-V5 -->
+```
+
+### §I — unreferenced interfaces
+
+1. Same logic as §V: collect all `I.*` references from active §T rows.
+2. For each I item NOT in live set → candidate for archive.
+3. Remove those interface lines from §I.
+4. Insert HTML comment above §I section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §I I.api,I.cli -->
+```
+
+### §C — unreferenced constraints
+
+1. Same logic as §V: collect all §C references from active §T rows.
+2. For each §C item NOT in live set → candidate for archive.
+3. Remove those constraint lines from §C.
+4. Insert HTML comment above §C section:
+
+```
+<!-- archive: .cavekit/archive/SPEC-<date>.md §C -->
+```
+
+### §G — never touched. Project identity.
+
+## REPORT
+
+Show diff of SPEC.md (before → after). Format:
+
+```
+## archive report
+
+saved to: .cavekit/archive/SPEC-2026-05-15.md
+
+§T archived: T1, T3-T8, T12 (9 tasks completed)
+§B archived: B1-B4 (4 bugs older than 90 days)
+§V archived: V1,V3-V5 (4 invariants, no active task cites them)
+§I archived: I.cli (1 interface, no active task cites it)
+§G §C untouched
+
+lines before: 542
+lines after: 218
+```
+
+Apply only on user OK.
+
+## RULES
+
+- Archive = full copy. Nothing lost. Ever.
+- `check` and `build` read `.cavekit/archive/` when they need historical context.
+- One archive file per run. Multiple runs = multiple files. Oldest = furthest history.
+- §G is sacred. Never remove.
+- §C, §V and §I archived only when no active §T (`.` or `~`) cites them.
+- After archive, spec and build skills parse archive comments for max ID.
+  New tasks continue T13+ if T1-T12 archived. Never reuse IDs.
+- New tasks may cite archived V/N or I/X — archive comment points to full text.

--- a/skills/backprop/SKILL.md
+++ b/skills/backprop/SKILL.md
@@ -25,6 +25,7 @@ That edit is backprop.
 ### 1. TRACE
 Read failure output / bug report.
 Find exact file:line of wrong behavior.
+Check `.cavekit/archive/` for similar past bugs — same invariant or same file pattern may have been fixed before.
 Name root cause in one caveman sentence.
 
 ### 2. ANALYZE

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -18,7 +18,7 @@ Single-thread native plan→execute. You are main Claude. No swarm.
 
 1. Read `SPEC.md`. If missing → tell user to invoke the spec skill first. Stop.
 2. Read `FORMAT.md` once if not loaded.
-3. Check `.cavekit/archive/` — if task cites an invariant that archive comments link to archived §T rows, read relevant archive file for context on how that invariant was previously implemented.
+3. Check `.cavekit/archive/` — if a task cites an invariant/interface that has been archived (per `<!-- archive: ... §V ... -->` / `§I` comments), read the referenced archive file for the full text/context.
 4. Parse invocation args:
    - `§T.n` → that task only
    - `--next` → lowest-numbered row with status `.` or `~`
@@ -66,6 +66,7 @@ Rule: never silently fix root-cause without considering backprop. §B is the mem
 ## VERIFICATION
 
 Task `x` only if:
+
 - Verification command exits 0.
 - New test(s) added per plan.
 - No §V invariant regressed (run full test suite at end).

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -18,7 +18,8 @@ Single-thread native plan→execute. You are main Claude. No swarm.
 
 1. Read `SPEC.md`. If missing → tell user to invoke the spec skill first. Stop.
 2. Read `FORMAT.md` once if not loaded.
-3. Parse invocation args:
+3. Check `.cavekit/archive/` — if task cites an invariant that archive comments link to archived §T rows, read relevant archive file for context on how that invariant was previously implemented.
+4. Parse invocation args:
    - `§T.n` → that task only
    - `--next` → lowest-numbered row with status `.` or `~`
    - `--all` or empty → every `.` row in §T order

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -21,7 +21,7 @@ Pure diagnostic. Reports violations. Writes nothing. User decides remedy.
    - `§V` → check invariants only (default)
    - `§I` → check interfaces
    - `§T` → audit task status vs code
-   - `--all` → all three
+   - `--all` → all three (§V + §I + §T), AND includes archived §T rows (read from `.cavekit/archive/`)
 
 ## CHECK §V — invariants
 
@@ -78,6 +78,7 @@ next: spec skill with `bug:` or fix code at cited lines.
 ## REMEDY HINTS (not actions)
 
 End report with one-line hint per class:
+
 - VIOLATE / DRIFT → invoke spec skill `bug: <V.n>` or fix code.
 - MISSING → invoke build skill on `§T.n` if task exists; else spec skill `amend §T`.
 - STALE → spec skill `amend §T` to uncheck.

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -16,7 +16,8 @@ Pure diagnostic. Reports violations. Writes nothing. User decides remedy.
 ## LOAD
 
 1. Read `SPEC.md`. If missing → "no spec, nothing to check." Stop.
-2. Parse invocation args:
+2. Check `.cavekit/archive/` dir. List archive files if present. Available for historical lookup.
+3. Parse invocation args:
    - `§V` → check invariants only (default)
    - `§I` → check interfaces
    - `§T` → audit task status vs code
@@ -24,7 +25,7 @@ Pure diagnostic. Reports violations. Writes nothing. User decides remedy.
 
 ## CHECK §V — invariants
 
-For each V<n>:
+For each V<n>, also check if archived §T rows cited this invariant (read relevant `.cavekit/archive/SPEC-<date>.md` if archive comments reference matching §T ranges).
 
 1. Translate invariant into verifiable claim about code.
 2. Grep / read relevant files.
@@ -43,6 +44,8 @@ For each I item:
    - **EXTRA** — code exposes surface not in §I.
 
 ## CHECK §T — tasks
+
+For each T<n> in working SPEC.md. Archived tasks checked only if user passes `--all` — read from `.cavekit/archive/`.
 
 For each T<n>:
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -72,7 +72,10 @@ Never silently rewrite sections user did not name.
 
 - Caveman format per `FORMAT.md`.
 - Preserve identifiers, paths, code verbatim.
-- Numbering monotonic — never reuse §V.N or §B.N.
+- Numbering monotonic — never reuse §V.N, §B.N, or §T.N.
+- Next ID = max(current table IDs + archive comment ranges) + 1.
+  Parse `<!-- archive: ... §T T1-T12 -->` to find archived ranges.
+  Never start from T1/B1 if archive comments exist.
 - §T row `cites` column ! list §V/§I deps: `T5|.|impl auth mw|V2,I.api`.
 
 ## NON-GOALS

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -30,6 +30,7 @@ Inspect user request and project state:
 Input: user idea.
 
 Steps:
+
 1. Extract goal (1 line, caveman). → §G.
 2. List constraints user stated or implied. → §C.
 3. List external surfaces user named. → §I.
@@ -50,6 +51,7 @@ Caveman everywhere. Flag uncertain items with `?` in text so user can confirm.
 Input: `bug: <description>`.
 
 Steps:
+
 1. Parse bug description.
 2. Find root cause (read relevant code).
 3. Decide: would a new invariant catch recurrence? If yes → draft `V<next>`.
@@ -73,9 +75,9 @@ Never silently rewrite sections user did not name.
 - Caveman format per `FORMAT.md`.
 - Preserve identifiers, paths, code verbatim.
 - Numbering monotonic — never reuse §V.N, §B.N, or §T.N.
-- Next ID = max(current table IDs + archive comment ranges) + 1.
-  Parse `<!-- archive: ... §T T1-T12 -->` to find archived ranges.
-  Never start from T1/B1 if archive comments exist.
+- Next IDs computed per section: nextT = 1 + max(current T ids, archived §T ids); nextB = 1 + max(current B ids, archived §B ids); nextV = 1 + max(current V ids, archived §V ids).
+  Parse archive comments like `<!-- archive: ... §T T1-T12 -->`, `<!-- archive: ... §B B1-B5 -->`, `<!-- archive: ... §V V1,V3-V5 -->` (comma lists + `Xn-Xm` ranges).
+  Never restart from T1/B1/V1 if any archive comment exists for that section.
 - §T row `cites` column ! list §V/§I deps: `T5|.|impl auth mw|V2,I.api`.
 
 ## NON-GOALS


### PR DESCRIPTION
## Why

  SPEC.md grows unbounded as projects accumulate tasks, bugs, and invariants. FORMAT.md mentions a 500-line limit but provides no mechanism to enforce it. Without compaction, spec files become expensive to load and slow to parse.

  ## What

  Adds `/archive` command — two-phase spec compaction:

  1. **RESEARCH** (dry-run) — scans SPEC.md, identifies what can be archived, shows exact `lines before → lines after`. No files touched.
  2. **ARCHIVE + TRIM** — only after user confirmation. Copies full SPEC.md to `.cavekit/archive/SPEC-<date>.md`, then trims working copy.

  Archives:
  - **§T** — completed tasks (status `x`)
  - **§B** — bugs older than 90 days
  - **§V** — invariants not cited by any active task
  - **§I** — interfaces not cited by any active task
  - **§C** — constraints not cited by any active task
  - **§G** — untouched (project identity)

  Archive comments in SPEC.md carry ID ranges (`<!-- archive: .cavekit/archive/SPEC-2026-05-15.md §T T1-T12 -->`) so numbering stays monotonic and new tasks can reference archived items.

  All existing skills (`spec`, `build`, `check`, `backprop`) updated to read `.cavekit/archive/` when needed.

  ## Files

  | file | change |
  |---|---|
  | `commands/archive.md` | new — `/archive` slash command |
  | `skills/archive/SKILL.md` | new — `/archive` skill |
  | `FORMAT.md` | ARCHIVE section + `/archive` in command table |
  | `commands/spec.md` | next ID parses archive comments |
  | `skills/spec/SKILL.md` | monotonic IDs across archives |
  | `skills/check/SKILL.md` | archive-aware drift checks |
  | `skills/build/SKILL.md` | reads archive for invariant context |
  | `skills/backprop/SKILL.md` | searches archive for similar past bugs |

  ## How to test

  ```bash
  1. Create a SPEC.md with 500+ lines
  2. Run /archive
  3. Verify dry-run shows correct lines before → lines after
  4. Confirm → verify .cavekit/archive/SPEC-<date>.md is exact copy
  5. Verify SPEC.md trimmed correctly, archive comments present
  6. Run /ck:spec — new tasks should continue numbering from archived max