### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #35)

### DIFF
--- a/commands/build.md
+++ b/commands/build.md
@@ -1,6 +1,6 @@
 ---
 description: Plan-then-execute against SPEC.md. Native Claude Code loop, no sub-agents.
-argument-hint: [§T.n | --all | --next]
+argument-hint: "[§T.n | --all | --next]"
 ---
 
 Invoke the **build** skill (`skills/build/SKILL.md`). Treat `$ARGUMENTS` as the

--- a/commands/check.md
+++ b/commands/check.md
@@ -1,6 +1,6 @@
 ---
 description: Drift detector. Diff SPEC.md against code. Read-only, zero writes.
-argument-hint: [§V | §I | §T | --all]
+argument-hint: "[§V | §I | §T | --all]"
 ---
 
 Invoke the **check** skill (`skills/check/SKILL.md`). Treat `$ARGUMENTS` as the

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Adversarial senior review of the spec before build. Refute, don't rubber-stamp. Ends in a go/no-go gate.
-argument-hint: [§T.n | --all]
+argument-hint: "[§T.n | --all]"
 ---
 
 Invoke the **review** skill (`skills/review/SKILL.md`). Construct a senior

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,6 +1,6 @@
 ---
 description: Create, amend, or backprop bug into SPEC.md. Sole mutator of spec.
-argument-hint: [bug: <description> | amend <§X.n> | from-code | <idea>]
+argument-hint: "[bug: <description> | amend <§X.n> | from-code | <idea>]"
 ---
 
 Invoke the **spec** skill (`skills/spec/SKILL.md`). Treat `$ARGUMENTS` as the mode:


### PR DESCRIPTION
Closes #35.

## Summary

Purely mechanical single-character transform to 4 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (4)

- `commands/check.md`
- `commands/build.md`
- `commands/review.md`
- `commands/spec.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
